### PR TITLE
Fix Incorrect Genesis Config for `--crosstest` Flag & Reduce Verbose Logging

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1771,8 +1771,8 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612044
 		}
-		cfg.Genesis = core.DefaultCrossDevGenesisBlock()
-		SetDNSDiscoveryDefaults(cfg, params.CrossDevGenesisHash)
+		cfg.Genesis = core.DefaultCrossTestGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.CrossTestGenesisHash)
 	case ctx.Bool(CrossDevFlag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612066
@@ -2111,6 +2111,8 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	// ##CROSS: config
 	case ctx.Bool(CrossFlag.Name):
 		genesis = core.DefaultCrossGenesisBlock()
+	case ctx.Bool(CrossTestFlag.Name):
+		genesis = core.DefaultCrossTestGenesisBlock()
 	case ctx.Bool(CrossDevFlag.Name):
 		genesis = core.DefaultCrossDevGenesisBlock()
 		// ##

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -168,7 +168,7 @@ func (c *Core) startNewRound(round *big.Int) {
 	if c.current == nil {
 		oldLogger = c.logger.New("old.round", -1, "old.seq", 0)
 	} else {
-		oldLogger = c.logger.New("old.round", c.current.Round().Uint64(), "old.sequence", c.current.Sequence().Uint64(), "old.state", c.state.String(), "old.proposer", c.valSet.GetProposer())
+		oldLogger = c.logger.New("old.round", c.current.Round().Uint64(), "old.sequence", c.current.Sequence().Uint64(), "old.state", c.state.String() /*, "old.proposer", c.valSet.GetProposer()*/)
 	}
 
 	// Create next view
@@ -211,7 +211,7 @@ func (c *Core) startNewRound(round *big.Int) {
 		c.newRoundChangeTimer()
 	}
 
-	oldLogger.Info("Istanbul: start new round", "next.round", newView.Round, "next.seq", newView.Sequence, "next.proposer", c.valSet.GetProposer(), "next.valSet", c.valSet.List(), "next.size", c.valSet.Size(), "next.IsProposer", c.IsProposer())
+	oldLogger.Info("Istanbul: start new round", "next.round", newView.Round, "next.seq", newView.Sequence, "next.proposer", c.valSet.GetProposer() /*"next.valSet", c.valSet.List(),*/, "next.size", c.valSet.Size(), "next.IsProposer", c.IsProposer())
 }
 
 // updateRoundState updates round state by checking if locking block is necessary


### PR DESCRIPTION
## Changes
1. Corrected the wrong genesis setting when the `--crosstest` flag is used in `SetEthConfig`.
   - Previously, the node incorrectly loaded the `crossdev` genesis for the `--crosstest` option.
   - Now, it properly applies the intended genesis configuration.

2. Shortened an overly verbose log message.
   - Previously, debug-level details were logged every time, making the logs excessively long.
   - Updated to display only essential information.

## Background
- When using the `--crosstest` flag in Dev/QA environments, an unintended `crossdev` genesis was loaded, causing confusion.
- The excessive log output made troubleshooting more difficult.

## Benefits
- The `--crosstest` flag now applies the correct genesis config, improving clarity for setup and testing.
- The log output is reduced, making it easier to identify key information quickly.

## Validation
- All existing local tests pass.
- Performed basic end-to-end tests to confirm no issues remain.
