### PR TITLE
Fix failed test cases due to encoding changes from RandomReveal addition in IstanbulExtra

### DIFF
--- a/core/types/istanbul_test.go
+++ b/core/types/istanbul_test.go
@@ -51,7 +51,7 @@ func TestExtractToIstanbulExtra(t *testing.T) {
 	}{
 		{
 			// normal case
-			hexutil.MustDecode("0xf85a80f8549444add0ec310f115a0e603b2d7db9f067778eaf8a94294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212946beaaed781d2d2ab6350f5c4566a2c6eaac407a6948be76812f765c24641ec63dc2852b378aba2b440c080c0"),
+			hexutil.MustDecode("0xf85b80f8549444add0ec310f115a0e603b2d7db9f067778eaf8a94294fc7e8f22b3bcdcf955dd7ff3ba2ed833f8212946beaaed781d2d2ab6350f5c4566a2c6eaac407a6948be76812f765c24641ec63dc2852b378aba2b440c080c080"),
 			&IstanbulExtra{
 				VanityData: []byte{},
 				Validators: []common.Address{
@@ -63,6 +63,7 @@ func TestExtractToIstanbulExtra(t *testing.T) {
 				CommittedSeal: [][]byte{},
 				Round:         0,
 				Vote:          nil,
+				RandomReveal:  []byte{},
 			},
 			nil,
 		},


### PR DESCRIPTION
I have fixed the failed test cases.
The RandomReveal field was added to the IstanbulExtra structure, which changed the encoded value.