### PR TITLE
[Performance] Increase cache to 8192 and Optimize TxPool Parameters

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -391,7 +391,7 @@ var (
 	CacheFlag = &cli.IntFlag{
 		Name:     "cache",
 		Usage:    "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode)",
-		Value:    1024,
+		Value:    8192, // ##CROSS: performance
 		Category: flags.PerfCategory,
 	}
 	CacheDatabaseFlag = &cli.IntFlag{

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -390,7 +390,7 @@ var (
 	// Performance tuning settings
 	CacheFlag = &cli.IntFlag{
 		Name:     "cache",
-		Usage:    "Megabytes of memory allocated to internal caching (default = 4096 mainnet full node, 128 light mode)",
+		Usage:    "Megabytes of memory allocated to internal caching (default = 8192 cross full node, 4096 mainnet full node, 128 light mode)",
 		Value:    8192, // ##CROSS: performance
 		Category: flags.PerfCategory,
 	}

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -146,12 +146,13 @@ var DefaultConfig = Config{
 	PriceLimit: 1,
 	PriceBump:  10,
 
-	AccountSlots: 16,
-	GlobalSlots:  4096 + 1024, // urgent + floating queue capacity with 4:1 ratio
-	AccountQueue: 64,
-	GlobalQueue:  1024,
-
-	Lifetime: 3 * time.Hour,
+	// ##CROSS: performance
+	AccountSlots: 128,
+	GlobalSlots:  8192 + 2048, // urgent + floating queue capacity with 4:1 ratio
+	AccountQueue: 256,
+	GlobalQueue:  32768,
+	Lifetime:     30 * time.Second,
+	// ##
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/core/txpool/legacypool/legacypool_test.go
+++ b/core/txpool/legacypool/legacypool_test.go
@@ -52,7 +52,20 @@ var (
 )
 
 func init() {
-	testTxPoolConfig = DefaultConfig
+	// ##CROSS: performance
+	testTxPoolConfig = Config{
+		NoLocals:     false,
+		Journal:      "transactions.rlp",
+		Rejournal:    time.Hour,
+		PriceLimit:   1,
+		PriceBump:    10,
+		AccountSlots: 16,
+		GlobalSlots:  4096 + 1024, // urgent + floating queue capacity with 4:1 ratio
+		AccountQueue: 64,
+		GlobalQueue:  1024,
+		Lifetime:     3 * time.Hour,
+	}
+	// ##
 	testTxPoolConfig.Journal = ""
 
 	cpy := *params.TestChainConfig


### PR DESCRIPTION
## Changes

- **Cache Settings**
  - Increased the `--cache` value from ** 1024** to **8192**.
  - **Reason**: In high-load environments, increasing the overall cache allocation optimizes database I/O and state caching performance.

- **TxPool Settings**
  - **AccountSlots**: Increased to allocate ample executable transaction slots per account, ensuring smooth processing even when a single account generates a high volume of transactions.
  - **GlobalSlots**: Adjusted to provide stability in processing during short-term transaction surges.
  - **AccountQueue**: Enlarged to ensure that non-executable transactions per account are adequately buffered when slots are occupied.
  - **GlobalQueue**: Configured to roughly cover the equivalent of 4 blocks' worth of transactions, absorbing sudden network-wide transaction spikes.
  - **Lifetime**: Set to 30 seconds to prevent stale transactions from lingering in the pool, given the rapid block generation.

## Background & Purpose

This PR aims to maximize node performance under high-load conditions by optimizing the default cache and txpool parameters.

- **Cache Optimization**: Increasing the cache value ensures that database I/O and state caching can handle the load more efficiently.
- **TxPool Optimization**: Adjustments to account and global slots/queues help maintain smooth transaction processing and quick finality, even during rapid transaction bursts.

## Testing

- Conducted benchmark tests in local and staging environments to validate improvements in transaction throughput, block generation speed, and memory usage.
- Continuous monitoring will be performed in production to ensure these optimizations are effective and to fine-tune further if necessary.

## Notes

- Further load testing and monitoring are recommended before deploying these changes into the production environment, as adjustments may be necessary based on real-world usage patterns.

