### PR TITLE
gasabs support contract deploy

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1907,11 +1907,14 @@ func (s *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.B
 	if err := tx.UnmarshalBinary(input); err != nil {
 		return common.Hash{}, err
 	}
-
 	// ##CROSS: gas abstraction
-	if s.gasAbs != nil && tx.To() != nil && tx.Type() == types.DynamicFeeTxType {
-		if _, ok := s.approvedAddress.Load(*tx.To()); ok {
-			logger := log.New("to", *tx.To(), "tx", tx.Hash().Hex())
+	if s.gasAbs != nil && tx.Type() == types.DynamicFeeTxType {
+		to := common.Address{}
+		if tx.To() != nil {
+			to = *tx.To()
+		}
+		if _, ok := s.approvedAddress.Load(to); ok {
+			logger := log.New("to", to, "tx", tx.Hash().Hex())
 			logger.Info("Request GasAbstraction")
 			if tx, err = s.gasAbs.SignFeeDelegateTransaction(ctx, tx); err != nil {
 				errlog := logger.Warn
@@ -1924,7 +1927,6 @@ func (s *TransactionAPI) SendRawTransaction(ctx context.Context, input hexutil.B
 			logger.Info("Successfully requested GasAbstraction")
 		}
 	}
-
 	return SubmitTransaction(ctx, s.b, tx)
 }
 


### PR DESCRIPTION

# PR: Add Gas Support for Contract Deployment Transactions

## Description
This PR implements a gas support mechanism for smart contract deployment transactions (where the `to` field is nil). In Ethereum transactions, when the `to` field is null, it indicates a contract creation transaction.

## Changes
- Improved transaction recipient address handling logic in `internal/ethapi/api.go`
- Added detection and gas support processing for contract deployment transactions

## Testing
- Completed testing for gas support on contract deployment transactions
- Verified no impact on regular transaction processing

