### PR TITLE
feat: limit backlog queueing

### DIFF
--- a/consensus/istanbul/core/errors.go
+++ b/consensus/istanbul/core/errors.go
@@ -22,9 +22,12 @@ var (
 	// errNotFromProposer is returned when received message is supposed to be from
 	// proposer.
 	errNotFromProposer = errors.New("message does not come from proposer")
-	// errFutureMessage is returned when current view is earlier than the
+	// errFutureMessage is returned when current view is 1 round/sequence earlier than the
 	// view of the received message.
 	errFutureMessage = errors.New("future message")
+	// errFarFutureMessage is returned when current view is 1+ round/sequence earlier than the
+	// view of the received message.
+	errFarFutureMessage = errors.New("far future message")
 	// errOldMessage is returned when the received message's view is earlier
 	// than current view.
 	errOldMessage = errors.New("old message")

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -17,8 +17,10 @@
 package core
 
 import (
+	"math/big"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/log"
@@ -116,6 +118,9 @@ func (c *Core) checkRequestMsg(request *Request) error {
 	if cmp := c.current.sequence.Cmp(request.Proposal.Number()); cmp > 0 {
 		return errOldMessage
 	} else if cmp < 0 {
+		if new(big.Int).Add(c.current.sequence, common.Big1).Cmp(request.Proposal.Number()) < 0 {
+			return errFarFutureMessage
+		}
 		return errFutureMessage
 	} else {
 		return nil

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -83,13 +83,13 @@ func (v *View) String() string {
 //	+2 if v >  y+1
 func (v *View) Cmp(y *View) int {
 	if cmp := v.Sequence.Cmp(y.Sequence); cmp != 0 {
-		if v.Sequence.Cmp(new(big.Int).Add(y.Sequence, common.Big1)) > 0 {
+		if new(big.Int).Add(y.Sequence, common.Big1).Cmp(v.Sequence) < 0 {
 			return 2
 		}
 		return cmp
 	}
 	if cmp := v.Round.Cmp(y.Round); cmp != 0 {
-		if v.Round.Cmp(new(big.Int).Add(y.Round, common.Big1)) > 0 {
+		if new(big.Int).Add(y.Round, common.Big1).Cmp(v.Round) < 0 {
 			return 2
 		}
 		return cmp

--- a/consensus/istanbul/types.go
+++ b/consensus/istanbul/types.go
@@ -80,12 +80,19 @@ func (v *View) String() string {
 //	-1 if v <  y
 //	 0 if v == y
 //	+1 if v >  y
+//	+2 if v >  y+1
 func (v *View) Cmp(y *View) int {
-	if v.Sequence.Cmp(y.Sequence) != 0 {
-		return v.Sequence.Cmp(y.Sequence)
+	if cmp := v.Sequence.Cmp(y.Sequence); cmp != 0 {
+		if v.Sequence.Cmp(new(big.Int).Add(y.Sequence, common.Big1)) > 0 {
+			return 2
+		}
+		return cmp
 	}
-	if v.Round.Cmp(y.Round) != 0 {
-		return v.Round.Cmp(y.Round)
+	if cmp := v.Round.Cmp(y.Round); cmp != 0 {
+		if v.Round.Cmp(new(big.Int).Add(y.Round, common.Big1)) > 0 {
+			return 2
+		}
+		return cmp
 	}
 	return 0
 }

--- a/consensus/istanbul/types_test.go
+++ b/consensus/istanbul/types_test.go
@@ -24,12 +24,12 @@ import (
 func TestViewCompare(t *testing.T) {
 	// test equality
 	srvView := &View{
-		Sequence: big.NewInt(2),
-		Round:    big.NewInt(1),
+		Sequence: big.NewInt(3),
+		Round:    big.NewInt(2),
 	}
 	tarView := &View{
-		Sequence: big.NewInt(2),
-		Round:    big.NewInt(1),
+		Sequence: big.NewInt(3),
+		Round:    big.NewInt(2),
 	}
 	if r := srvView.Cmp(tarView); r != 0 {
 		t.Errorf("source(%v) should be equal to target(%v): have %v, want %v", srvView, tarView, r, 0)
@@ -37,33 +37,51 @@ func TestViewCompare(t *testing.T) {
 
 	// test larger Sequence
 	tarView = &View{
-		Sequence: big.NewInt(1),
-		Round:    big.NewInt(1),
+		Sequence: big.NewInt(2),
+		Round:    big.NewInt(2),
 	}
 	if r := srvView.Cmp(tarView); r != 1 {
 		t.Errorf("source(%v) should be larger than target(%v): have %v, want %v", srvView, tarView, r, 1)
+	}
+
+	// test more larger Sequence
+	tarView = &View{
+		Sequence: big.NewInt(1),
+		Round:    big.NewInt(2),
+	}
+	if r := srvView.Cmp(tarView); r != 2 {
+		t.Errorf("source(%v) should be larger than target(%v): have %v, want %v", srvView, tarView, r, 2)
 	}
 
 	// test larger Round
 	tarView = &View{
-		Sequence: big.NewInt(2),
-		Round:    big.NewInt(0),
+		Sequence: big.NewInt(3),
+		Round:    big.NewInt(1),
 	}
 	if r := srvView.Cmp(tarView); r != 1 {
 		t.Errorf("source(%v) should be larger than target(%v): have %v, want %v", srvView, tarView, r, 1)
 	}
 
-	// test smaller Sequence
+	// test more larger Round
 	tarView = &View{
 		Sequence: big.NewInt(3),
-		Round:    big.NewInt(1),
+		Round:    big.NewInt(0),
+	}
+	if r := srvView.Cmp(tarView); r != 2 {
+		t.Errorf("source(%v) should be larger than target(%v): have %v, want %v", srvView, tarView, r, 2)
+	}
+
+	// test smaller Sequence
+	tarView = &View{
+		Sequence: big.NewInt(4),
+		Round:    big.NewInt(2),
 	}
 	if r := srvView.Cmp(tarView); r != -1 {
 		t.Errorf("source(%v) should be smaller than target(%v): have %v, want %v", srvView, tarView, r, -1)
 	}
 	tarView = &View{
-		Sequence: big.NewInt(2),
-		Round:    big.NewInt(2),
+		Sequence: big.NewInt(3),
+		Round:    big.NewInt(3),
 	}
 	if r := srvView.Cmp(tarView); r != -1 {
 		t.Errorf("source(%v) should be smaller than target(%v): have %v, want %v", srvView, tarView, r, -1)


### PR DESCRIPTION
## Summary

This PR filters so-called "future" consensus messages.

## As Is

- If a consensus message is larger than current sequence, round or step, it is classified as future message.
- Future messages are added to the backlog and they will be processed after current one is handled.
- Because there is no restriction to the backlog size, It could consume huge portion of system memory and affect system performance if some malicious validators send manipulated messages.

## To Be

- If a message's sequence or round is 1+ larger than current sequence or round, it is not added to the backlog - it is just dropped.

## Test

- In the simulated environment, consensus messages were randomly dropped.
- With 4 or more active validators, there was no problem running consensus engine and blocks are normally produced.
- With 3 active validators, consensus engine freezes time to time, but it is recovered after 2-3 seconds.

## Conclusion

In normal situation, this message drop does not happen.
Even in the extreme situation, our engine is stable enough to run block mining smoothly.
In unexpected situation like receiving manipulated messages, this update will keep system from exhausting its resources.