### PR TITLE
# Hotfix: BuyGas Overflow Issue & MaxPriorityFeePerGas Enhancement

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -284,6 +284,9 @@ func (st *StateTransition) buyGas() error {
 			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
 		}
 	} else {
+		if have, want := st.state.GetBalance(payer).ToBig(), mgval; have.Cmp(want) < 0 {
+			return ErrFeePayerInsufficientFunds
+		}
 		if have, want := st.state.GetBalance(st.msg.From).ToBig(), st.msg.Value; have.Cmp(want) < 0 {
 			return fmt.Errorf("%w: address %v have %v want %v", ErrInsufficientFunds, st.msg.From.Hex(), have, want)
 		}

--- a/graphql/graphql.go
+++ b/graphql/graphql.go
@@ -324,7 +324,7 @@ func (t *Transaction) MaxPriorityFeePerGas(ctx context.Context) *hexutil.Big {
 		return nil
 	}
 	switch tx.Type() {
-	case types.DynamicFeeTxType, types.BlobTxType:
+	case types.DynamicFeeTxType, types.BlobTxType, types.FeeDelegatedDynamicFeeTxType: // ##CROSS: feedelegation
 		return (*hexutil.Big)(tx.GasTipCap())
 	default:
 		return nil


### PR DESCRIPTION
## Overview

This pull request addresses two critical issues in the transaction processing logic:
1. A potential overflow in `buygas` when the fee payer’s balance is insufficient.
2. Missing support for `FeeDelegatedDynamicFeeTxType` in the `MaxPriorityFeePerGas` function.

---

## 1. BuyGas Overflow Issue

**Problem Description**  
When calling `buygas` in the `applyTransaction` function, there was no check to ensure the fee payer had sufficient balance. If the fee payer’s balance was less than `gasPrice * gasLimit`, subtracting this fee could cause an overflow.

**Resolution**  
If the fee payer differs from `st.msg.From` and does not have enough balance, the code returns an `ErrFeePayerInsufficientFunds` error immediately. Below is the relevant snippet:

```go
if payer == st.msg.From {
    // existing logic...
} else {
    if have, want := st.state.GetBalance(payer).ToBig(), mgval; have.Cmp(want) < 0 {
        return ErrFeePayerInsufficientFunds
    }
    // existing logic...
}
```

## 2. Enhancement to MaxPriorityFeePerGas
**Problem Description**  
Previously, the MaxPriorityFeePerGas function only returned valid values for DynamicFeeTxType and BlobTxType.
Fee-delegated transactions (FeeDelegatedDynamicFeeTxType) were not supported, resulting in an incorrect return value for these transactions.

**Resolution**  
By adding a case for FeeDelegatedDynamicFeeTxType in the switch statement, all dynamic fee transactions now correctly return their Gas Tip Cap.

```go
func (t *Transaction) MaxPriorityFeePerGas(ctx context.Context) *hexutil.Big {
    tx, _ := t.resolve(ctx)
    if tx == nil {
        return nil
    }
    switch tx.Type() {
    case types.DynamicFeeTxType, types.BlobTxType, types.FeeDelegatedDynamicFeeTxType:
        return (*hexutil.Big)(tx.GasTipCap())
    default:
        return nil
    }
}
```
## Testing & Verification 
**Unit Tests** 

Confirmed that an error (ErrFeePayerInsufficientFunds) is triggered if the fee payer does not have a sufficient balance.

Ensured MaxPriorityFeePerGas returns the correct value for FeeDelegatedDynamicFeeTxType.

**Manual Tests** 

Simulated transactions locally to verify that no overflow occurs when buygas is invoked.

Confirmed that fee-delegated transactions now function properly with the enhanced MaxPriorityFeePerGas.

**Conclusion** 
1. Prevent Overflow
By returning an error beforehand if the fee payer has insufficient balance, the overflow issue in buygas is avoided.

2. Improved Fee Delegation Compatibility
With MaxPriorityFeePerGas now supporting FeeDelegatedDynamicFeeTxType, the dynamic fee mechanism is more robust and versatile.

This hotfix ensures safer transaction processing and a more comprehensive handling of fee-delegated transactions.
