### PR TITLE
Rename CrossTest to ZoneZero and Crossway fork to Adventure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # 🚀 Go Cross
 
-Go Cross is a **blockchain client based on Ethereum v1.13.15**, integrating ConsenSys Quorum's latest BFT consensus algorithm. It features **Crossway Fork, a custom fork that incorporates elements from the Shanghai and Cancun forks**.
+Go Cross is a **blockchain client based on Ethereum v1.13.15**, integrating ConsenSys Quorum's latest BFT consensus algorithm. It features **Adventure Fork, a custom fork that incorporates elements from the Shanghai and Cancun forks**.
 
 ## 🔢 Version Information
 
 - **Execution Layer: Ethereum**: v1.13.15
 - **Consensus Layer: ConsenSys Quorum**: Latest BFT-based consensus algorithm
-- **Fork Version**: Crossway Fork (Shanghai + partial Cancun features applied)
+- **Fork Version**: Adventure Fork (Shanghai + partial Cancun features applied)
 
 ## 🛠 Installation and Execution Guide
 

--- a/cmd/devp2p/nodesetcmd.go
+++ b/cmd/devp2p/nodesetcmd.go
@@ -231,8 +231,8 @@ func ethFilter(args []string) (nodeFilter, error) {
 	// ##CROSS: config
 	case "cross":
 		filter = forkid.NewStaticFilter(params.CrossChainConfig, core.DefaultCrossGenesisBlock().ToBlock())
-	case "crosstest":
-		filter = forkid.NewStaticFilter(params.CrossTestChainConfig, core.DefaultCrossTestGenesisBlock().ToBlock())
+	case "zonezero":
+		filter = forkid.NewStaticFilter(params.ZoneZeroChainConfig, core.DefaultZoneZeroGenesisBlock().ToBlock())
 	case "crossdev3":
 		filter = forkid.NewStaticFilter(params.CrossDev3ChainConfig, core.DefaultCrossDev3GenesisBlock().ToBlock())
 	case "crossdev":

--- a/cmd/evm/internal/t8ntool/execution.go
+++ b/cmd/evm/internal/t8ntool/execution.go
@@ -158,8 +158,8 @@ func (pre *Prestate) Apply(vmConfig vm.Config, chainConfig *params.ChainConfig,
 		GetHash:     getHash,
 	}
 	// ##CROSS: transfer log
-	// update Transfer function for Crossway fork.
-	if chainConfig.IsCrossway(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
+	// update Transfer function for Adventure fork.
+	if chainConfig.IsAdventure(new(big.Int).SetUint64(pre.Env.Number), pre.Env.Timestamp) {
 		vmContext.Transfer = core.CrossTransfer
 	}
 	// ##

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -204,8 +204,8 @@ func initGenesis(ctx *cli.Context) error {
 		// ##CROSS: config
 		case "cross":
 			genesis = core.DefaultCrossGenesisBlock()
-		case "crosstest":
-			genesis = core.DefaultCrossTestGenesisBlock()
+		case "zonezero":
+			genesis = core.DefaultZoneZeroGenesisBlock()
 		case "crossdev3":
 			genesis = core.DefaultCrossDev3GenesisBlock()
 		case "crossdev":
@@ -440,8 +440,8 @@ func importHistory(ctx *cli.Context) error {
 		// ##CROSS: config
 		case ctx.Bool(utils.CrossFlag.Name):
 			network = "cross"
-		case ctx.Bool(utils.CrossTestFlag.Name):
-			network = "crosstest"
+		case ctx.Bool(utils.ZoneZeroFlag.Name):
+			network = "zonezero"
 		case ctx.Bool(utils.CrossDev3Flag.Name):
 			network = "crossdev3"
 		case ctx.Bool(utils.CrossDevFlag.Name):

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -282,8 +282,8 @@ func prepare(ctx *cli.Context) {
 	case ctx.IsSet(utils.CrossFlag.Name):
 		log.Info("Starting Geth on Cross mainnet...")
 
-	case ctx.IsSet(utils.CrossTestFlag.Name):
-		log.Info("Starting Geth on Cross testnet...")
+	case ctx.IsSet(utils.ZoneZeroFlag.Name):
+		log.Info("Starting Geth on Cross ZoneZero testnet...")
 
 	case ctx.IsSet(utils.CrossDev3Flag.Name):
 		log.Info("Starting Geth on Cross dev3net...")
@@ -328,7 +328,7 @@ func prepare(ctx *cli.Context) {
 	if !ctx.IsSet(utils.CacheFlag.Name) && !ctx.IsSet(utils.NetworkIdFlag.Name) {
 		// Make sure we're not on any supported preconfigured testnet either
 		if !ctx.IsSet(utils.CrossFlag.Name) && // ##CROSS: config
-			ctx.IsSet(utils.CrossTestFlag.Name) &&
+			ctx.IsSet(utils.ZoneZeroFlag.Name) &&
 			ctx.IsSet(utils.CrossDev3Flag.Name) &&
 			ctx.IsSet(utils.CrossDevFlag.Name) && // ##
 			!ctx.IsSet(utils.MainnetFlag.Name) &&

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -141,8 +141,8 @@ var (
 		Usage:    "Cross mainnet",
 		Category: flags.EthCategory,
 	}
-	CrossTestFlag = &cli.BoolFlag{
-		Name:     "crosstest",
+	ZoneZeroFlag = &cli.BoolFlag{
+		Name:     "zonezero",
 		Usage:    "Cross testnet",
 		Category: flags.EthCategory,
 	}
@@ -936,7 +936,7 @@ var (
 	// TestnetFlags is the flag group of all built-in supported testnets.
 	TestnetFlags = []cli.Flag{
 		// ##CROSS: config
-		CrossTestFlag,
+		ZoneZeroFlag,
 		CrossDev3Flag,
 		CrossDevFlag,
 		// ##
@@ -1029,8 +1029,8 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		}
 		switch {
 		// ##CROSS: config
-		case ctx.Bool(CrossTestFlag.Name):
-			urls = params.CrossTestBootnodes
+		case ctx.Bool(ZoneZeroFlag.Name):
+			urls = params.ZoneZeroBootnodes
 		case ctx.Bool(CrossDev3Flag.Name):
 			urls = params.CrossDev3Bootnodes
 		case ctx.Bool(CrossDevFlag.Name):
@@ -1622,8 +1622,8 @@ func CheckExclusive(ctx *cli.Context, args ...interface{}) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Avoid conflicting network flags
-	CheckExclusive(ctx, CrossFlag, CrossTestFlag, CrossDev3Flag, CrossDevFlag, MainnetFlag, DeveloperFlag, GoerliFlag, SepoliaFlag, HoleskyFlag) // ##CROSS: config
-	CheckExclusive(ctx, DeveloperFlag, ExternalSignerFlag)                                                                                       // Can't use both ephemeral unlocked and external signer
+	CheckExclusive(ctx, CrossFlag, ZoneZeroFlag, CrossDev3Flag, CrossDevFlag, MainnetFlag, DeveloperFlag, GoerliFlag, SepoliaFlag, HoleskyFlag) // ##CROSS: config
+	CheckExclusive(ctx, DeveloperFlag, ExternalSignerFlag)                                                                                      // Can't use both ephemeral unlocked and external signer
 
 	// Set configurations from CLI flags
 	setEtherbase(ctx, cfg)
@@ -1775,12 +1775,12 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.Genesis = core.DefaultCrossGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.CrossGenesisHash)
-	case ctx.Bool(CrossTestFlag.Name):
+	case ctx.Bool(ZoneZeroFlag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612044
 		}
-		cfg.Genesis = core.DefaultCrossTestGenesisBlock()
-		SetDNSDiscoveryDefaults(cfg, params.CrossTestGenesisHash)
+		cfg.Genesis = core.DefaultZoneZeroGenesisBlock()
+		SetDNSDiscoveryDefaults(cfg, params.ZoneZeroGenesisHash)
 	case ctx.Bool(CrossDev3Flag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612088
@@ -2125,8 +2125,8 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	// ##CROSS: config
 	case ctx.Bool(CrossFlag.Name):
 		genesis = core.DefaultCrossGenesisBlock()
-	case ctx.Bool(CrossTestFlag.Name):
-		genesis = core.DefaultCrossTestGenesisBlock()
+	case ctx.Bool(ZoneZeroFlag.Name):
+		genesis = core.DefaultZoneZeroGenesisBlock()
 	case ctx.Bool(CrossDev3Flag.Name):
 		genesis = core.DefaultCrossDev3GenesisBlock()
 	case ctx.Bool(CrossDevFlag.Name):

--- a/core/cross_transfer_log_test.go
+++ b/core/cross_transfer_log_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 var (
-	testUnit           = int64(1_000_000_000_000_000_000)
-	testBigUnit        = big.NewInt(testUnit)
-	testKey1, _        = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-	testKey2, _        = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
-	testAddr1          = crypto.PubkeyToAddress(testKey1.PublicKey)
-	testAddr2          = crypto.PubkeyToAddress(testKey2.PublicKey)
-	testChainID        = big.NewInt(612044)
-	testCrosswayConfig = &params.ChainConfig{ // config with crossway fork
+	testUnit            = int64(1_000_000_000_000_000_000)
+	testBigUnit         = big.NewInt(testUnit)
+	testKey1, _         = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+	testKey2, _         = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+	testAddr1           = crypto.PubkeyToAddress(testKey1.PublicKey)
+	testAddr2           = crypto.PubkeyToAddress(testKey2.PublicKey)
+	testChainID         = big.NewInt(612044)
+	testAdventureConfig = &params.ChainConfig{ // config with Adventure fork
 		ChainID:                       testChainID,
 		HomesteadBlock:                big.NewInt(0),
 		DAOForkBlock:                  big.NewInt(0),
@@ -48,7 +48,7 @@ var (
 		TerminalTotalDifficulty:       common.Big0,
 		TerminalTotalDifficultyPassed: true,
 		ShanghaiTime:                  u64(0),
-		CrosswayTime:                  u64(0),
+		AdventureTime:                 u64(0),
 	}
 )
 
@@ -65,7 +65,7 @@ func TestCrossTransferSig(t *testing.T) {
 func TestAddTransferLog_transferTx(t *testing.T) {
 	var (
 		gspec = &Genesis{
-			Config: testCrosswayConfig,
+			Config: testAdventureConfig,
 			Alloc: types.GenesisAlloc{
 				testAddr1: types.Account{
 					Balance: big.NewInt(2 * testUnit),
@@ -74,7 +74,7 @@ func TestAddTransferLog_transferTx(t *testing.T) {
 			},
 		}
 		gspecWithCrossEx = &Genesis{
-			Config: testCrosswayConfig,
+			Config: testAdventureConfig,
 			Alloc: types.GenesisAlloc{
 				predeploy.CrossExAddr: types.Account{
 					Code: common.Hex2Bytes(predeploy.CrossExBinRuntime),
@@ -95,8 +95,8 @@ func TestAddTransferLog_transferTx(t *testing.T) {
 		}
 	)
 
-	configNoCross := *testCrosswayConfig
-	configNoCross.CrosswayTime = nil
+	configNoCross := *testAdventureConfig
+	configNoCross.AdventureTime = nil
 
 	for _, tt := range []struct {
 		name      string
@@ -128,7 +128,7 @@ func TestAddTransferLog_transferTx(t *testing.T) {
 			noReceipt: true,
 		},
 		{
-			name: "no crossway",
+			name: "no Adventure",
 			gspec: &Genesis{
 				Config: &configNoCross,
 				Alloc: types.GenesisAlloc{
@@ -221,7 +221,7 @@ func TestAddTransferLog_callContract(t *testing.T) {
 		receivedSig = common.HexToHash("0x88a5966d370b9919b20f3e2c13ff65706f196a4e32cc2c12bf57088f88525874")
 
 		gspec = &Genesis{
-			Config: testCrosswayConfig,
+			Config: testAdventureConfig,
 			Alloc: types.GenesisAlloc{
 				predeploy.CrossExAddr: types.Account{
 					Code: common.Hex2Bytes(predeploy.CrossExBinRuntime),

--- a/core/evm.go
+++ b/core/evm.go
@@ -43,7 +43,7 @@ type ChainContext interface {
 // NewEVMBlockContext creates a new context for use in the EVM.
 func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common.Address, config *params.ChainConfig) vm.BlockContext {
 	// ##CROSS: transfer log
-	// Parameter config is added to check if the Crossway fork is enabled
+	// Parameter config is added to check if the Adventure fork is enabled
 
 	var (
 		beneficiary common.Address
@@ -72,8 +72,8 @@ func NewEVMBlockContext(header *types.Header, chain ChainContext, author *common
 	}
 	// ##CROSS: transfer log
 	transfer := Transfer
-	// Update Transfer function for Crossway fork
-	if config != nil && config.IsCrossway(header.Number, header.Time) {
+	// Update Transfer function for Adventure fork
+	if config != nil && config.IsAdventure(header.Number, header.Time) {
 		transfer = CrossTransfer
 	}
 	// ##

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -369,8 +369,8 @@ func (g *Genesis) configOrDefault(ghash common.Hash) *params.ChainConfig {
 		// ##CROSS: config
 	case ghash == params.CrossGenesisHash:
 		return params.CrossChainConfig
-	case ghash == params.CrossTestGenesisHash:
-		return params.CrossTestChainConfig
+	case ghash == params.ZoneZeroGenesisHash:
+		return params.ZoneZeroChainConfig
 	case ghash == params.CrossDev3GenesisHash:
 		return params.CrossDev3ChainConfig
 	case ghash == params.CrossDevGenesisHash:
@@ -514,18 +514,18 @@ func DefaultCrossGenesisBlock() *Genesis {
 	}
 }
 
-// DefaultCrossTestGenesisBlock returns the Cross dev net genesis block.
-func DefaultCrossTestGenesisBlock() *Genesis {
+// DefaultZoneZeroGenesisBlock returns the Cross dev net genesis block.
+func DefaultZoneZeroGenesisBlock() *Genesis {
 	return &Genesis{
-		Config:     params.CrossTestChainConfig,
+		Config:     params.ZoneZeroChainConfig,
 		Nonce:      0xeeff,
 		Timestamp:  0x67ae9b37,
 		ExtraData:  hexutil.MustDecode("0xc680c0c080c080"),
 		GasLimit:   105000000,
 		Difficulty: istanbul.DefaultDifficulty,
 		Mixhash:    types.IstanbulDigest,
-		Coinbase:   params.FoundationCrossTest,
-		Alloc:      predeploy.GenesisAllocCrossTest,
+		Coinbase:   params.FoundationZoneZero,
+		Alloc:      predeploy.GenesisAllocZoneZero,
 	}
 }
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -88,10 +88,10 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "cross testnet block in DB, genesis == nil",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				return SetupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(scheme)), DefaultCrossTestGenesisBlock())
+				return SetupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(scheme)), DefaultZoneZeroGenesisBlock())
 			},
-			wantHash:   params.CrossTestGenesisHash,
-			wantConfig: params.CrossTestChainConfig,
+			wantHash:   params.ZoneZeroGenesisHash,
+			wantConfig: params.ZoneZeroChainConfig,
 		},
 		{
 			name: "cross dev3 block in DB, genesis == nil",

--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -58,8 +58,8 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 	switch {
 	case evm.chainRules.IsCancun:
 		table = &cancunInstructionSet
-	case evm.chainRules.IsCrossway: // ##CROSS: fork
-		table = &crosswayInstructionSet
+	case evm.chainRules.IsAdventure: // ##CROSS: fork
+		table = &adventureInstructionSet
 	case evm.chainRules.IsShanghai:
 		table = &shanghaiInstructionSet
 	case evm.chainRules.IsMerge:

--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -56,7 +56,7 @@ var (
 	londonInstructionSet           = newLondonInstructionSet()
 	mergeInstructionSet            = newMergeInstructionSet()
 	shanghaiInstructionSet         = newShanghaiInstructionSet()
-	crosswayInstructionSet         = newCrosswayInstructionSet() // ##CROSS: fork
+	adventureInstructionSet        = newAdventureInstructionSet() // ##CROSS: fork
 	cancunInstructionSet           = newCancunInstructionSet()
 )
 
@@ -91,7 +91,7 @@ func newCancunInstructionSet() JumpTable {
 	return validate(instructionSet)
 }
 
-func newCrosswayInstructionSet() JumpTable { // ##CROSS: fork
+func newAdventureInstructionSet() JumpTable { // ##CROSS: fork
 	instructionSet := newShanghaiInstructionSet()
 	enable1153(&instructionSet) // EIP-1153 "Transient Storage"
 	enable5656(&instructionSet) // EIP-5656 (MCOPY opcode)

--- a/core/vm/runtime/env.go
+++ b/core/vm/runtime/env.go
@@ -42,7 +42,7 @@ func NewEnv(cfg *Config) *vm.EVM {
 		Random:      cfg.Random,
 	}
 	// ##CROSS: transfer log
-	if cfg.ChainConfig.IsCrossway(cfg.BlockNumber, cfg.Time) {
+	if cfg.ChainConfig.IsAdventure(cfg.BlockNumber, cfg.Time) {
 		blockContext.Transfer = core.CrossTransfer
 	}
 	// ##

--- a/params/bootnodes.go
+++ b/params/bootnodes.go
@@ -32,9 +32,9 @@ var CrossBootnodes = []string{
 	"enode://386a39b22749ea3ae9d1df537c086a7101b64fd87ea2402ba6eaa9e11bb09ce4c2ef0bda120680a3da34917cf3ceff29a219a2d6f649ad9dbd15029af5728ad5@54.169.215.240:30303",
 }
 
-// CrossTestBootnodes are the enode URLs of the P2P bootstrap nodes running on
+// ZoneZeroBootnodes are the enode URLs of the P2P bootstrap nodes running on
 // the cross test network.
-var CrossTestBootnodes = []string{
+var ZoneZeroBootnodes = []string{
 	"enode://c7d9c0b82ecacd85bf5db814baf630dd19ab82d89180fedcac4e6fb6f4bbd7298e5094b1fefd8b213d7cef56d911c6d15564607d093f140fb3577a2d58011633@3.38.60.4:30303",
 	"enode://8a0f705c2b784c9c97e4d2a6e4f3ef0ea688fe1fae524ba53c0ec6d7fd0670ed952b053d3058785e60f51af7fec50264de61c10508030704768642a8cfafffc1@3.39.185.231:30303",
 }
@@ -133,8 +133,8 @@ func KnownDNSNetwork(genesis common.Hash, protocol string) string {
 	// ##CROSS: config
 	case CrossGenesisHash:
 		net = "cross"
-	case CrossTestGenesisHash:
-		net = "crosstest"
+	case ZoneZeroGenesisHash:
+		net = "zonezero"
 	case CrossDev3GenesisHash:
 		net = "crossdev3"
 	case CrossDevGenesisHash:

--- a/params/config.go
+++ b/params/config.go
@@ -29,17 +29,17 @@ import (
 var (
 	// ##CROSS: config
 	CrossGenesisHash     = common.HexToHash("0x9a48f4d9c0c73b86fd1abb239649223e89fc0797b90f7c7982999900f57c21b0")
-	CrossTestGenesisHash = common.HexToHash("0xa570e4b2e71338415b8b7e51e639511398a93067322cfce5698a870a89813c03")
+	ZoneZeroGenesisHash  = common.HexToHash("0xa570e4b2e71338415b8b7e51e639511398a93067322cfce5698a870a89813c03")
 	CrossDev3GenesisHash = common.HexToHash("0x1ba8d18d400eae1f2e181bf853edb8c001ab645c57caeb780699608c5cd1ba3c")
 	CrossDevGenesisHash  = common.HexToHash("0xfe493d82314ce8a829cce13681cd9d5886bf7e78665d392edaac4f6e9c14ce77")
 
 	FoundationCross     = common.HexToAddress("0xb5e06b1ab772c63aa2e3795eba9b14a63f9785fd")
-	FoundationCrossTest = common.HexToAddress("0x06Dc63E28d18172A689213071884c66c5281b493")
+	FoundationZoneZero  = common.HexToAddress("0x06Dc63E28d18172A689213071884c66c5281b493")
 	FoundationCrossDev3 = common.HexToAddress("0xB9032595eC0465f43de9CF68c1E230888a5d16b6")
 	FoundationCrossDev  = common.HexToAddress("0xB9032595eC0465f43de9CF68c1E230888a5d16b6")
 
 	BeneficiaryCross     = common.HexToAddress("0xb5e06b1ab772c63aa2e3795eba9b14a63f9785fd")
-	BeneficiaryCrossTest = common.HexToAddress("0x579c60A3176C5B588aeAD61a1F878a6A19CCc84E")
+	BeneficiaryZoneZero  = common.HexToAddress("0x579c60A3176C5B588aeAD61a1F878a6A19CCc84E")
 	BeneficiaryCrossDev3 = common.HexToAddress("0xB9032595eC0465f43de9CF68c1E230888a5d16b6")
 	BeneficiaryCrossDev  = common.HexToAddress("0xB9032595eC0465f43de9CF68c1E230888a5d16b6")
 
@@ -74,7 +74,7 @@ var (
 		TerminalTotalDifficulty:       nil,
 		TerminalTotalDifficultyPassed: false,
 		ShanghaiTime:                  newUint64(0),
-		CrosswayTime:                  newUint64(0), // ##CROSS: fork
+		AdventureTime:                 newUint64(0), // ##CROSS: fork
 		CancunTime:                    nil,
 		Istanbul: &IstanbulConfig{
 			EpochLength:             86400,
@@ -114,7 +114,7 @@ var (
 		Transitions: []Transition{},
 	}
 
-	CrossTestChainConfig = &ChainConfig{
+	ZoneZeroChainConfig = &ChainConfig{
 		ChainID:                       big.NewInt(612044),
 		HomesteadBlock:                big.NewInt(0),
 		DAOForkBlock:                  big.NewInt(0),
@@ -134,7 +134,7 @@ var (
 		TerminalTotalDifficulty:       nil,
 		TerminalTotalDifficultyPassed: false,
 		ShanghaiTime:                  newUint64(0),
-		CrosswayTime:                  newUint64(0), // ##CROSS: fork
+		AdventureTime:                 newUint64(0), // ##CROSS: fork
 		CancunTime:                    nil,
 		Istanbul: &IstanbulConfig{
 			EpochLength:             86400,
@@ -165,7 +165,7 @@ var (
 				common.HexToAddress("0x99e64cE38a0042d706E9D0b1c01E3A506Ee80F90"),
 			},
 			MaxRequestTimeoutSeconds: newUint64(60),
-			Beneficiary:              &BeneficiaryCrossTest,
+			Beneficiary:              &BeneficiaryZoneZero,
 			ElasticityMultiplier:     newUint64(3),
 			BaseFeeChangeDenominator: newUint64(8),
 			MaxBaseFee:               (*math.HexOrDecimal256)(big.NewInt(1e18)), // 1 Ether
@@ -194,7 +194,7 @@ var (
 		TerminalTotalDifficulty:       nil,
 		TerminalTotalDifficultyPassed: false,
 		ShanghaiTime:                  newUint64(0),
-		CrosswayTime:                  newUint64(0), // ##CROSS: fork
+		AdventureTime:                 newUint64(0), // ##CROSS: fork
 		CancunTime:                    nil,
 		Istanbul: &IstanbulConfig{
 			EpochLength:             86400,
@@ -237,7 +237,7 @@ var (
 		TerminalTotalDifficulty:       nil,
 		TerminalTotalDifficultyPassed: false,
 		ShanghaiTime:                  newUint64(0),
-		CrosswayTime:                  newUint64(0), // ##CROSS: fork
+		AdventureTime:                 newUint64(0), // ##CROSS: fork
 		CancunTime:                    nil,
 		Istanbul: &IstanbulConfig{
 			EpochLength:             86400,
@@ -537,7 +537,7 @@ var (
 var NetworkNames = map[string]string{
 	// ##CROSS: config
 	CrossChainConfig.ChainID.String():     "cross",
-	CrossTestChainConfig.ChainID.String(): "crosstest",
+	ZoneZeroChainConfig.ChainID.String():  "zonezero",
 	CrossDev3ChainConfig.ChainID.String(): "crossdev3",
 	CrossDevChainConfig.ChainID.String():  "crossdev",
 	// ##
@@ -578,11 +578,11 @@ type ChainConfig struct {
 
 	// Fork scheduling was switched from blocks to timestamps here
 
-	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
-	CrosswayTime *uint64 `json:"crosswayTime,omitempty"` // Crossway switch time (nil = no fork, 0 = already on crosswayTime) ##CROSS: fork
-	CancunTime   *uint64 `json:"cancunTime,omitempty"`   // Cancun switch time (nil = no fork, 0 = already on cancun)
-	PragueTime   *uint64 `json:"pragueTime,omitempty"`   // Prague switch time (nil = no fork, 0 = already on prague)
-	VerkleTime   *uint64 `json:"verkleTime,omitempty"`   // Verkle switch time (nil = no fork, 0 = already on verkle)
+	ShanghaiTime  *uint64 `json:"shanghaiTime,omitempty"`  // Shanghai switch time (nil = no fork, 0 = already on shanghai)
+	AdventureTime *uint64 `json:"adventureTime,omitempty"` // Adventure switch time (nil = no fork, 0 = already on AdventureTime) ##CROSS: fork
+	CancunTime    *uint64 `json:"cancunTime,omitempty"`    // Cancun switch time (nil = no fork, 0 = already on cancun)
+	PragueTime    *uint64 `json:"pragueTime,omitempty"`    // Prague switch time (nil = no fork, 0 = already on prague)
+	VerkleTime    *uint64 `json:"verkleTime,omitempty"`    // Verkle switch time (nil = no fork, 0 = already on verkle)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -800,9 +800,9 @@ func (c *ChainConfig) IsShanghai(num *big.Int, time uint64) bool {
 	return c.IsLondon(num) && isTimestampForked(c.ShanghaiTime, time)
 }
 
-// IsCrossway returns whether time is either equal to the Crossway fork time or greater. ##CROSS: fork
-func (c *ChainConfig) IsCrossway(num *big.Int, time uint64) bool {
-	return c.IsLondon(num) && isTimestampForked(c.CrosswayTime, time)
+// IsAdventure returns whether time is either equal to the Adventure fork time or greater. ##CROSS: fork
+func (c *ChainConfig) IsAdventure(num *big.Int, time uint64) bool {
+	return c.IsLondon(num) && isTimestampForked(c.AdventureTime, time)
 }
 
 // IsCancun returns whether num is either equal to the Cancun fork time or greater.
@@ -1012,8 +1012,8 @@ func (c *ChainConfig) LatestFork(time uint64) forks.Fork {
 		return forks.Prague
 	case c.IsCancun(london, time):
 		return forks.Cancun
-	case c.IsCrossway(london, time): // ##CROSS: fork
-		return forks.Crossway
+	case c.IsAdventure(london, time): // ##CROSS: fork
+		return forks.Adventure
 	case c.IsShanghai(london, time):
 		return forks.Shanghai
 	default:
@@ -1153,7 +1153,7 @@ type Rules struct {
 	IsByzantium, IsConstantinople, IsPetersburg, IsIstanbul bool
 	IsBerlin, IsLondon                                      bool
 	IsMerge, IsShanghai                                     bool
-	IsCrossway                                              bool // ##CROSS: fork
+	IsAdventure                                             bool // ##CROSS: fork
 	IsCancun, IsPrague                                      bool
 	IsVerkle                                                bool
 }
@@ -1180,7 +1180,7 @@ func (c *ChainConfig) Rules(num *big.Int, isMerge bool, timestamp uint64) Rules 
 		IsLondon:         c.IsLondon(num),
 		IsMerge:          isMerge,
 		IsShanghai:       isMerge && c.IsShanghai(num, timestamp),
-		IsCrossway:       isMerge && c.IsCrossway(num, timestamp), // ##CROSS: fork
+		IsAdventure:      isMerge && c.IsAdventure(num, timestamp), // ##CROSS: fork
 		IsCancun:         isMerge && c.IsCancun(num, timestamp),
 		IsPrague:         isMerge && c.IsPrague(num, timestamp),
 		IsVerkle:         isMerge && c.IsVerkle(num, timestamp),

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -37,7 +37,7 @@ const (
 	GrayGlacier
 	Paris
 	Shanghai
-	Crossway // ##CROSS: fork
+	Adventure // ##CROSS: fork
 	Cancun
 	Prague
 )

--- a/params/predeploy/configs.go
+++ b/params/predeploy/configs.go
@@ -42,8 +42,8 @@ var (
 		},
 	}
 
-	GenesisAllocCrossTest = types.GenesisAlloc{
-		params.FoundationCrossTest: {
+	GenesisAllocZoneZero = types.GenesisAlloc{
+		params.FoundationZoneZero: {
 			Balance: new(big.Int).Mul(big.NewInt(1_000_000_000_000), big.NewInt(1e18)),
 		},
 		CrossExAddr:    GenesisAllocCross[CrossExAddr],


### PR DESCRIPTION
## Overview
The `go-cross` project’s default testnet and fork names have been updated as follows:

- **Old testnet**: `CrossTest` → **New testnet**: `ZoneZero`  
- **Old fork name**: `Crossway` → **New fork name**: `Adventure`  

## Changes
1. **Constants & Variable Names Updated**  
   - Renamed all variables and constants from `"CrossTest"` to `"ZoneZero"`  
   - Renamed fork client type names, option keys, etc. from `"Crossway"` to `"Adventure"`

2. **Flag Update**  
   - Renamed the `-crosstest` flag to `-zonezero`

3. **README Updates**  
   - Updated fork name references from `Crossway` to `Adventure`

