### PR TITLE
Feature/istanbul stats

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -202,7 +202,9 @@ func makeFullNode(ctx *cli.Context) (*node.Node, ethapi.Backend) {
 	}
 	// Add the Ethereum Stats daemon if requested.
 	if cfg.Ethstats.URL != "" {
-		utils.RegisterEthStatsService(stack, backend, cfg.Ethstats.URL)
+		//## CROSS: istanbul stats
+		// blockchain is injected
+		utils.RegisterEthStatsService(stack, backend, eth.BlockChain(), cfg.Ethstats.URL)
 	}
 	// Configure full-sync tester service if requested
 	if ctx.IsSet(utils.SyncTargetFlag.Name) {

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -1936,8 +1936,10 @@ func RegisterEthService(stack *node.Node, cfg *ethconfig.Config) (ethapi.Backend
 }
 
 // RegisterEthStatsService configures the Ethereum Stats daemon and adds it to the node.
-func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, url string) {
-	if err := ethstats.New(stack, backend, backend.Engine(), url); err != nil {
+func RegisterEthStatsService(stack *node.Node, backend ethapi.Backend, chain *core.BlockChain, url string) {
+	//## CROSS: istanbul stats
+	// blockchain is injected
+	if err := ethstats.New(stack, backend, backend.Engine(), chain, url); err != nil {
 		Fatalf("Failed to register the Ethereum Stats service: %v", err)
 	}
 }

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -296,6 +296,23 @@ func (sb *Backend) Stop() error {
 	return nil
 }
 
+// ##CROSS: istanbul stats
+
+// Started returns true if the engine has been started.
+func (sb *Backend) Started() bool {
+	return sb.coreStarted
+}
+
+// CurrentView returns the current view of the engine.
+func (sb *Backend) CurrentView() *istanbul.View {
+	if sb.core != nil {
+		return sb.core.CurrentView()
+	}
+	return nil
+}
+
+// ##
+
 func addrsToString(addrs []common.Address) []string {
 	strs := make([]string, len(addrs))
 	for i, addr := range addrs {

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -300,6 +300,8 @@ func (sb *Backend) Stop() error {
 
 // Started returns true if the engine has been started.
 func (sb *Backend) Started() bool {
+	sb.coreMu.RLock()
+	defer sb.coreMu.RUnlock()
 	return sb.coreStarted
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -313,6 +313,15 @@ func (sb *Backend) CurrentView() *istanbul.View {
 	return nil
 }
 
+// ValidatorsFrom returns the validator set from the given chain at the given proposal.
+func (sb *Backend) ValidatorsFrom(chain consensus.ChainHeaderReader, proposal istanbul.Proposal) istanbul.ValidatorSet {
+	snap, err := sb.snapshot(chain, proposal.Number().Uint64(), proposal.Hash(), nil)
+	if err != nil {
+		return validator.NewSet(nil, sb.config.ProposerPolicy)
+	}
+	return snap.ValSet
+}
+
 // ##
 
 func addrsToString(addrs []common.Address) []string {

--- a/consensus/istanbul/core/commit.go
+++ b/consensus/istanbul/core/commit.go
@@ -70,7 +70,7 @@ func (c *Core) broadcastCommit() {
 		return
 	}
 
-	withMsg(logger, commit).Info("Istanbul: broadcast COMMIT message", "payload", hexutil.Encode(payload))
+	withMsg(logger, commit).Debug("Istanbul: broadcast COMMIT message", "payload", hexutil.Encode(payload))
 
 	// Broadcast RLP-encoded message
 	if err = c.backend.Broadcast(c.valSet, commit.Code(), payload); err != nil {
@@ -88,7 +88,7 @@ func (c *Core) broadcastCommit() {
 func (c *Core) handleCommitMsg(commit *protocols.Commit) error {
 	logger := c.currentLogger(true, commit)
 
-	logger.Info("Istanbul: handle COMMIT message", "commits.count", c.current.Commits.Size(), "quorum", c.valSet.QuorumSize())
+	logger.Debug("Istanbul: handle COMMIT message", "commits.count", c.current.Commits.Size(), "quorum", c.valSet.QuorumSize())
 
 	// Check digest
 	if commit.Digest != c.current.Proposal().Hash() {
@@ -98,7 +98,7 @@ func (c *Core) handleCommitMsg(commit *protocols.Commit) error {
 
 	// Add to received msgs
 	if err := c.current.Commits.Add(commit); err != nil {
-		c.logger.Error("Istanbul: failed to save COMMIT message", "err", err)
+		logger.Error("Istanbul: failed to save COMMIT message", "err", err)
 		return err
 	}
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -243,7 +243,7 @@ func (c *Core) setState(state State) {
 	if c.state != state {
 		oldState := c.state
 		c.state = state
-		c.currentLogger(false, nil).Info("Istanbul: changed state", "old.state", oldState.String(), "new.state", state.String())
+		c.currentLogger(false, nil).Debug("Istanbul: changed state", "old.state", oldState.String(), "new.state", state.String())
 	}
 	if state == StateAcceptRequest {
 		c.processPendingRequests()

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -98,6 +98,8 @@ type Core struct {
 
 // ##CROSS: istanbul stats
 func (c *Core) CurrentView() *istanbul.View {
+	c.currentMutex.Lock()
+	defer c.currentMutex.Unlock()
 	return c.currentView()
 }
 

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -145,7 +145,7 @@ func (c *Core) startNewRound(round *big.Int) {
 		logger = logger.New("lastProposal.number", lastProposal.Number().Uint64(), "lastProposal.hash", lastProposal.Hash())
 	}
 
-	logger.Info("Istanbul: initialize new round")
+	logger.Debug("Istanbul: initialize new round")
 
 	if c.current == nil {
 		logger.Debug("Istanbul: start at the initial round")

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -96,6 +96,13 @@ type Core struct {
 	newRoundTimer *time.Timer
 }
 
+// ##CROSS: istanbul stats
+func (c *Core) CurrentView() *istanbul.View {
+	return c.currentView()
+}
+
+// ##
+
 func (c *Core) currentView() *istanbul.View {
 	return &istanbul.View{
 		Sequence: new(big.Int).Set(c.current.Sequence()),
@@ -168,7 +175,7 @@ func (c *Core) startNewRound(round *big.Int) {
 	if c.current == nil {
 		oldLogger = c.logger.New("old.round", -1, "old.seq", 0)
 	} else {
-		oldLogger = c.logger.New("old.round", c.current.Round().Uint64(), "old.sequence", c.current.Sequence().Uint64(), "old.state", c.state.String() /*, "old.proposer", c.valSet.GetProposer()*/)
+		oldLogger = c.logger.New("old.round", c.current.Round().Uint64(), "old.sequence", c.current.Sequence().Uint64(), "old.state", c.state.String(), "old.proposer", c.valSet.GetProposer())
 	}
 
 	// Create next view

--- a/consensus/istanbul/core/core.go
+++ b/consensus/istanbul/core/core.go
@@ -220,7 +220,14 @@ func (c *Core) startNewRound(round *big.Int) {
 		c.newRoundChangeTimer()
 	}
 
-	oldLogger.Info("Istanbul: start new round", "next.round", newView.Round, "next.seq", newView.Sequence, "next.proposer", c.valSet.GetProposer() /*"next.valSet", c.valSet.List(),*/, "next.size", c.valSet.Size(), "next.IsProposer", c.IsProposer())
+	oldLogger.Info("Istanbul: start new round",
+		"next.round", newView.Round,
+		"next.seq", newView.Sequence,
+		"next.proposer", c.valSet.GetProposer(),
+		"next.valSet", c.valSet.List(),
+		"next.size", c.valSet.Size(),
+		"next.IsProposer", c.IsProposer(),
+	)
 }
 
 // updateRoundState updates round state by checking if locking block is necessary

--- a/consensus/istanbul/core/final_committed.go
+++ b/consensus/istanbul/core/final_committed.go
@@ -19,7 +19,7 @@ package core
 import "github.com/ethereum/go-ethereum/common"
 
 func (c *Core) handleFinalCommitted() error {
-	c.currentLogger(true, nil).Info("Istanbul: handle final committed")
+	c.currentLogger(true, nil).Debug("Istanbul: handle final committed")
 
 	// Stopping the timer, so that round changes do not happen
 	c.stopTimer()

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -290,6 +290,7 @@ func (c *Core) currentLogger(state bool, msg protocols.Message) log.Logger {
 		logCtx = append(logCtx,
 			"current.round", c.current.Round().Uint64(),
 			"current.sequence", c.current.Sequence().Uint64(),
+			"current.proposer", c.valSet.GetProposer().Address(), // ##CROSS: istanbul stats
 		)
 	}
 

--- a/consensus/istanbul/core/handler.go
+++ b/consensus/istanbul/core/handler.go
@@ -290,7 +290,7 @@ func (c *Core) currentLogger(state bool, msg protocols.Message) log.Logger {
 		logCtx = append(logCtx,
 			"current.round", c.current.Round().Uint64(),
 			"current.sequence", c.current.Sequence().Uint64(),
-			"current.proposer", c.valSet.GetProposer().Address(), // ##CROSS: istanbul stats
+			"current.proposer", c.valSet.GetProposer().Address(),
 		)
 	}
 

--- a/consensus/istanbul/core/prepare.go
+++ b/consensus/istanbul/core/prepare.go
@@ -55,7 +55,7 @@ func (c *Core) broadcastPrepare() {
 		return
 	}
 
-	withMsg(logger, prepare).Info("Istanbul: broadcast PREPARE message", "payload", hexutil.Encode(payload))
+	withMsg(logger, prepare).Debug("Istanbul: broadcast PREPARE message", "payload", hexutil.Encode(payload))
 
 	// Broadcast RLP-encoded message
 	if err = c.backend.Broadcast(c.valSet, prepare.Code(), payload); err != nil {
@@ -73,7 +73,7 @@ func (c *Core) broadcastPrepare() {
 func (c *Core) handlePrepare(prepare *protocols.Prepare) error {
 	logger := c.currentLogger(true, prepare).New()
 
-	logger.Info("Istanbul: handle PREPARE message", "prepares.count", c.current.Prepares.Size(), "quorum", c.valSet.QuorumSize(), "prepare.digest", prepare.Digest.Hex())
+	logger.Debug("Istanbul: handle PREPARE message", "prepares.count", c.current.Prepares.Size(), "quorum", c.valSet.QuorumSize(), "prepare.digest", prepare.Digest.Hex())
 
 	// Check digest
 	if prepare.Digest != c.current.Proposal().Hash() {
@@ -92,7 +92,7 @@ func (c *Core) handlePrepare(prepare *protocols.Prepare) error {
 	// Change to "Prepared" state if we've received quorum of PREPARE messages
 	// and we are in earlier state than "Prepared"
 	if (c.current.Prepares.Size() >= c.valSet.QuorumSize()) && c.state.Cmp(StatePrepared) < 0 {
-		logger.Info("Istanbul: received quorum of PREPARE messages")
+		logger.Debug("Istanbul: received quorum of PREPARE messages")
 
 		// Accumulates PREPARE messages
 		c.current.preparedRound = c.currentView().Round

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -114,14 +114,16 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 
 	// Validates PRE-PREPARE message comes from current proposer
 	if !c.valSet.IsProposer(preprepare.Source()) {
-		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer", "proposer", c.valSet.GetProposer().Address())
+		// ##CROSS: istanbul stats
+		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer", "source", preprepare.Source()) //"proposer", c.valSet.GetProposer().Address())
 		return errNotFromProposer
 	}
 
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {
 		if err := isJustified(preprepare.Proposal, preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {
-			logger.Warn("Istanbul: invalid PRE-PREPARE message justification", "err", err)
+			// ##CROSS: istanbul stats
+			logger.Warn("Istanbul: invalid PRE-PREPARE message justification", "err", err, "quorum", c.valSet.QuorumSize())
 			return errInvalidPreparedBlock
 		}
 	}

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -109,6 +109,7 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 	logger := c.currentLogger(true, preprepare)
 
 	logger = logger.New("proposal.number", preprepare.Proposal.Number().Uint64(), "proposal.hash", preprepare.Proposal.Hash().String())
+	logger.Debug("Istanbul: handle PRE-PREPARE message")
 
 	// Validates PRE-PREPARE message comes from current proposer
 	if !c.valSet.IsProposer(preprepare.Source()) {
@@ -116,8 +117,6 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer")
 		return errNotFromProposer
 	}
-
-	logger.Debug("Istanbul: handle PRE-PREPARE message")
 
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -152,7 +152,7 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 
 	// Here is about to accept the PRE-PREPARE
 	if c.state == StateAcceptRequest {
-		c.logger.Info("Istanbul: accepted PRE-PREPARE message")
+		logger.Debug("Istanbul: accepted PRE-PREPARE message")
 
 		// Re-initialize ROUND-CHANGE timer
 		c.newRoundChangeTimer()

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -110,14 +110,14 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 
 	logger = logger.New("proposal.number", preprepare.Proposal.Number().Uint64(), "proposal.hash", preprepare.Proposal.Hash().String())
 
-	c.logger.Info("Istanbul: handle PRE-PREPARE message")
-
 	// Validates PRE-PREPARE message comes from current proposer
 	if !c.valSet.IsProposer(preprepare.Source()) {
 		// ##CROSS: istanbul stats
 		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer")
 		return errNotFromProposer
 	}
+
+	logger.Debug("Istanbul: handle PRE-PREPARE message")
 
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -86,7 +86,7 @@ func (c *Core) sendPreprepareMsg(request *Request) {
 
 		logger = withMsg(logger, preprepare).New("block.number", preprepare.Proposal.Number().Uint64(), "block.hash", preprepare.Proposal.Hash().String())
 
-		logger.Info("Istanbul: broadcast PRE-PREPARE message", "payload", hexutil.Encode(payload))
+		logger.Debug("Istanbul: broadcast PRE-PREPARE message", "payload", hexutil.Encode(payload))
 
 		// Broadcast RLP-encoded message
 		if err = c.backend.Broadcast(c.valSet, preprepare.Code(), payload); err != nil {

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -115,7 +115,7 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 	// Validates PRE-PREPARE message comes from current proposer
 	if !c.valSet.IsProposer(preprepare.Source()) {
 		// ##CROSS: istanbul stats
-		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer", "source", preprepare.Source()) //"proposer", c.valSet.GetProposer().Address())
+		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer")
 		return errNotFromProposer
 	}
 

--- a/consensus/istanbul/core/preprepare.go
+++ b/consensus/istanbul/core/preprepare.go
@@ -113,7 +113,6 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 
 	// Validates PRE-PREPARE message comes from current proposer
 	if !c.valSet.IsProposer(preprepare.Source()) {
-		// ##CROSS: istanbul stats
 		logger.Warn("Istanbul: ignore PRE-PREPARE message from non proposer")
 		return errNotFromProposer
 	}
@@ -121,7 +120,6 @@ func (c *Core) handlePreprepareMsg(preprepare *protocols.Preprepare) error {
 	// Validates PRE-PREPARE message justification
 	if preprepare.Round.Uint64() > 0 {
 		if err := isJustified(preprepare.Proposal, preprepare.JustificationRoundChanges, preprepare.JustificationPrepares, c.valSet.QuorumSize()); err != nil {
-			// ##CROSS: istanbul stats
 			logger.Warn("Istanbul: invalid PRE-PREPARE message justification", "err", err, "quorum", c.valSet.QuorumSize())
 			return errInvalidPreparedBlock
 		}

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 )
 
 // handleRequest is called by proposer in reaction to `miner.Seal()`
@@ -71,7 +70,8 @@ func (c *Core) handleRequest(request *Request) error {
 				config := c.config.GetConfig(c.current.Sequence())
 
 				if config.EmptyBlockPeriod > config.BlockPeriod {
-					log.Info("EmptyBlockPeriod detected adding delay to request", "EmptyBlockPeriod", config.EmptyBlockPeriod, "BlockTime", block.Time())
+					// ##CROSS: istanbul stats
+					logger.Info("Istanbul: EmptyBlockPeriod detected adding delay to request", "EmptyBlockPeriod", config.EmptyBlockPeriod, "BlockTime", block.Time())
 					// Because the seal has an additional delay on the block period you need to subtract it from the delay
 					delay = time.Duration(config.EmptyBlockPeriod-config.BlockPeriod) * time.Second
 					header := block.Header()
@@ -153,11 +153,13 @@ func (c *Core) processPendingRequests() {
 		err := c.checkRequestMsg(r)
 		if err != nil {
 			if err == errFutureMessage {
-				logger.Trace("Istanbul: stop looking up for pending block proposal request")
+				// ##CROSS: istanbul stats
+				logger.Trace("Istanbul: future message, stop looking up for pending block proposal request", "proposal.number", r.Proposal.Number(), "proposal.hash", r.Proposal.Hash())
 				c.pendingRequests.Push(r, prio)
 				break
 			}
-			logger.Trace("Istanbul: skip pending invalid block proposal request", "number", r.Proposal.Number(), "hash", r.Proposal.Hash(), "err", err)
+			// ##CROSS: istanbul stats
+			logger.Trace("Istanbul: skip pending invalid block proposal request", "proposal.number", r.Proposal.Number(), "proposal.hash", r.Proposal.Hash(), "err", err)
 			continue
 		}
 		logger.Debug("Istanbul: found pending block proposal request", "proposal.number", r.Proposal.Number(), "proposal.hash", r.Proposal.Hash())

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -33,6 +33,7 @@ import (
 // - creates and send PRE-PREPARE message to other validators
 func (c *Core) handleRequest(request *Request) error {
 	logger := c.currentLogger(true, nil)
+	logger.Info("Istanbul: handle block proposal request")
 
 	if err := c.checkRequestMsg(request); err != nil {
 		if err == errInvalidMessage {
@@ -42,8 +43,6 @@ func (c *Core) handleRequest(request *Request) error {
 		}
 		return err
 	}
-
-	logger.Info("Istanbul: handle block proposal request")
 
 	c.current.pendingRequest = request
 	if c.state == StateAcceptRequest {

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -34,8 +34,6 @@ import (
 func (c *Core) handleRequest(request *Request) error {
 	logger := c.currentLogger(true, nil)
 
-	logger.Info("Istanbul: handle block proposal request")
-
 	if err := c.checkRequestMsg(request); err != nil {
 		if err == errInvalidMessage {
 			logger.Error("Istanbul: invalid request")
@@ -44,6 +42,8 @@ func (c *Core) handleRequest(request *Request) error {
 		}
 		return err
 	}
+
+	logger.Info("Istanbul: handle block proposal request")
 
 	c.current.pendingRequest = request
 	if c.state == StateAcceptRequest {

--- a/consensus/istanbul/core/request.go
+++ b/consensus/istanbul/core/request.go
@@ -69,7 +69,6 @@ func (c *Core) handleRequest(request *Request) error {
 				config := c.config.GetConfig(c.current.Sequence())
 
 				if config.EmptyBlockPeriod > config.BlockPeriod {
-					// ##CROSS: istanbul stats
 					logger.Info("Istanbul: EmptyBlockPeriod detected adding delay to request", "EmptyBlockPeriod", config.EmptyBlockPeriod, "BlockTime", block.Time())
 					// Because the seal has an additional delay on the block period you need to subtract it from the delay
 					delay = time.Duration(config.EmptyBlockPeriod-config.BlockPeriod) * time.Second
@@ -152,12 +151,10 @@ func (c *Core) processPendingRequests() {
 		err := c.checkRequestMsg(r)
 		if err != nil {
 			if err == errFutureMessage {
-				// ##CROSS: istanbul stats
 				logger.Trace("Istanbul: future message, stop looking up for pending block proposal request", "proposal.number", r.Proposal.Number(), "proposal.hash", r.Proposal.Hash())
 				c.pendingRequests.Push(r, prio)
 				break
 			}
-			// ##CROSS: istanbul stats
 			logger.Trace("Istanbul: skip pending invalid block proposal request", "proposal.number", r.Proposal.Number(), "proposal.hash", r.Proposal.Hash(), "err", err)
 			continue
 		}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/protocols"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 )
 
@@ -138,12 +137,14 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 		// we start new round and broadcast ROUND-CHANGE message
 		newRound := c.roundChangeSet.getMinRoundChange(currentRound)
 
-		logger.Info("Istanbul: received F+1 ROUND-CHANGE messages", "F", c.valSet.F())
+		// ##CROSS: istanbul stats
+		logger.Info("Istanbul: received F+1 ROUND-CHANGE messages", "F", c.valSet.F(), "newRound", newRound.Uint64())
 
 		c.startNewRound(newRound)
 		c.broadcastRoundChange(newRound)
 	} else if currentRoundMessages >= c.valSet.QuorumSize() && c.IsProposer() && c.current.preprepareSent.Cmp(currentRound) < 0 {
-		logger.Info("Istanbul: received quorum of ROUND-CHANGE messages")
+		// ##CROSS: istanbul stats
+		logger.Info("Istanbul: received quorum of ROUND-CHANGE messages", "quorum", c.valSet.QuorumSize())
 
 		// We received quorum of ROUND-CHANGE for current round and we are proposer
 
@@ -155,7 +156,8 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 			if c.current != nil && c.current.pendingRequest != nil {
 				proposal = c.current.pendingRequest.Proposal
 			} else {
-				log.Warn("round change returns an error: no proposal as pending request is nil")
+				// ##CROSS: istanbul stats
+				logger.Warn("Istanbul: round change returns an error: no proposal as pending request is nil")
 				return errors.New("no proposal as pending request is nil")
 			}
 		}
@@ -170,7 +172,8 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 
 		prepareMessages := c.roundChangeSet.prepareMessages[currentRound.Uint64()]
 		if err := isJustified(proposal, rcSignedPayloads, prepareMessages, c.valSet.QuorumSize()); err != nil {
-			logger.Error("Istanbul: invalid ROUND-CHANGE message justification", "err", err)
+			// ##CROSS: istanbul stats
+			logger.Error("Istanbul: invalid ROUND-CHANGE message justification", "err", err, "quorum", c.valSet.QuorumSize())
 			return nil
 		}
 

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -137,13 +137,11 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 		// we start new round and broadcast ROUND-CHANGE message
 		newRound := c.roundChangeSet.getMinRoundChange(currentRound)
 
-		// ##CROSS: istanbul stats
 		logger.Info("Istanbul: received F+1 ROUND-CHANGE messages", "F", c.valSet.F(), "newRound", newRound.Uint64())
 
 		c.startNewRound(newRound)
 		c.broadcastRoundChange(newRound)
 	} else if currentRoundMessages >= c.valSet.QuorumSize() && c.IsProposer() && c.current.preprepareSent.Cmp(currentRound) < 0 {
-		// ##CROSS: istanbul stats
 		logger.Info("Istanbul: received quorum of ROUND-CHANGE messages", "quorum", c.valSet.QuorumSize())
 
 		// We received quorum of ROUND-CHANGE for current round and we are proposer
@@ -156,7 +154,6 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 			if c.current != nil && c.current.pendingRequest != nil {
 				proposal = c.current.pendingRequest.Proposal
 			} else {
-				// ##CROSS: istanbul stats
 				logger.Warn("Istanbul: round change returns an error: no proposal as pending request is nil")
 				return errors.New("no proposal as pending request is nil")
 			}
@@ -172,7 +169,6 @@ func (c *Core) handleRoundChange(roundChange *protocols.RoundChange) error {
 
 		prepareMessages := c.roundChangeSet.prepareMessages[currentRound.Uint64()]
 		if err := isJustified(proposal, rcSignedPayloads, prepareMessages, c.valSet.QuorumSize()); err != nil {
-			// ##CROSS: istanbul stats
 			logger.Error("Istanbul: invalid ROUND-CHANGE message justification", "err", err, "quorum", c.valSet.QuorumSize())
 			return nil
 		}

--- a/consensus/istanbul/core/roundchange.go
+++ b/consensus/istanbul/core/roundchange.go
@@ -81,7 +81,7 @@ func (c *Core) broadcastRoundChange(round *big.Int) {
 		return
 	}
 
-	withMsg(logger, roundChange).Info("Istanbul: broadcast ROUND-CHANGE message", "payload", hexutil.Encode(data))
+	withMsg(logger, roundChange).Debug("Istanbul: broadcast ROUND-CHANGE message", "payload", hexutil.Encode(data))
 
 	// Broadcast RLP-encoded message
 	if err = c.backend.Broadcast(c.valSet, roundChange.Code(), data); err != nil {

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -92,6 +92,7 @@ type miningNodeBackend interface {
 
 // ##CROSS: istanbul stats
 type istanbulBackend interface {
+	Address() common.Address
 	Started() bool
 	CurrentView() *istanbul.View
 	Validators(proposal istanbul.Proposal) istanbul.ValidatorSet
@@ -499,6 +500,7 @@ type nodeInfo struct {
 	OsVer    string `json:"os_v"`
 	Client   string `json:"client"`
 	History  bool   `json:"canUpdateHistory"`
+	Address  string `json:"address"`
 }
 
 // authMsg is the authentication infos needed to login to a monitoring server.
@@ -539,6 +541,10 @@ func (s *Service) login(conn *connWrapper) error {
 		},
 		Secret: s.pass,
 	}
+	if s.istBackend != nil {
+		auth.Info.Address = s.istBackend.Address().Hex()
+	}
+
 	login := map[string][]interface{}{
 		"emit": {"hello", auth},
 	}

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -104,11 +104,14 @@ type istanbulBackend interface {
 // Service implements an Ethereum netstats reporting daemon that pushes local
 // chain statistics up to a monitoring server.
 type Service struct {
-	server     *p2p.Server // Peer-to-peer server to retrieve networking infos
-	backend    backend
-	engine     consensus.Engine            // Consensus engine to retrieve variadic block fields
-	istBackend istanbulBackend             // ##CROSS: istanbul stats
-	chain      consensus.ChainHeaderReader // ##CROSS: istanbul stats
+	server  *p2p.Server // Peer-to-peer server to retrieve networking infos
+	backend backend
+	engine  consensus.Engine // Consensus engine to retrieve variadic block fields
+
+	// ##CROSS: istanbul stats
+	istBackend istanbulBackend
+	chain      consensus.ChainHeaderReader
+	// ##
 
 	node string // Name of the node to display on the monitoring page
 	pass string // Password to authorize access to the monitoring page

--- a/ethstats/ethstats.go
+++ b/ethstats/ethstats.go
@@ -883,7 +883,7 @@ func (s *Service) reportStats(conn *connWrapper) error {
 }
 
 // ##CROSS: istanbul stats
-// istanbulStats is the information to report about the consensus layer.
+// istanbulStats is the information to report about the istanbul consensus layer.
 type istanbulStats struct {
 	Number         *big.Int         `json:"number"`
 	Validators     []common.Address `json:"validators"`
@@ -895,8 +895,8 @@ type istanbulStats struct {
 	HasBadProposal bool             `json:"hasBadProposal"`
 }
 
-// reportIstanbul retrieves various stats about the consensus layer and reports
-// it to the stats server.
+// reportIstanbul retrieves various stats about the istanbul consensus layer and
+// reports it to the stats server.
 func (s *Service) reportIstanbul(conn *connWrapper, block *types.Block) error {
 	if s.istBackend == nil || !s.istBackend.Started() {
 		// istanbul is not ready
@@ -922,6 +922,15 @@ func (s *Service) reportIstanbul(conn *connWrapper, block *types.Block) error {
 		istStats.Round = view.Round.Uint64()
 	}
 
+	log.Trace("Sending istanbul stats to ethstats",
+		"number", istStats.Number,
+		"validators", len(istStats.Validators),
+		"proposer", istStats.Proposer,
+		"sequence", istStats.Sequence,
+		"round", istStats.Round,
+		"hasBadProposal", istStats.HasBadProposal,
+	)
+
 	stats := map[string]interface{}{
 		"id":       s.node,
 		"istanbul": istStats,
@@ -929,7 +938,6 @@ func (s *Service) reportIstanbul(conn *connWrapper, block *types.Block) error {
 	report := map[string][]interface{}{
 		"emit": {"istanbul", stats},
 	}
-	// log.Trace("Sending istanbul stats to ethstats", "report", report)
 	return conn.WriteJSON(report)
 }
 


### PR DESCRIPTION
## Summary

This PR adds a status report of `istanbul` consensus engine to `ethstats` service and detailed logs to the istanbul package.

## Features

- Detailed log
  - In the `istanbul` package, every log is updated to emit more details, like current proposer, round, quorum size, etcetera.
- Status report
  - `istanbul` backend is injected into `ethstats` service.
  - When a full or block report is sent, an istanbul report is also sent altogether.

## Protocol

`istanbul` is added to the ethstats protocol.

```json
{
  "emit": {
    "istanbul": {
      "id": "<node_id>",
      "istanbul": {
        "number": "0x...", // proposal number
        "validators": ["0x...", "0x..."], // sorted list of validators
        "proposer": "0x...",
        "quorum": <ceil(2*validators.length/3)>,
        "f": <ceil(validators.length/3) - 1>,
        "sequence": <sequence_number>,
        "round": <round_number>,
        "hasBadProposal": false
      }
    }
  }
}
```

## Result

This update introduces the ability to monitor consensus status by transmitting its details to the status server. This enhancement will offer greater convenience to node operators.

The updated logs offer insights into the current progress of the consensus process. This allows us to quickly investigate any delays or issues that may arise during the consensus procedure.