### PR TITLE
fix: proposer sort policy

### DIFF
--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -567,7 +567,7 @@ func (sb *Backend) snapApplyHeader(snap *Snapshot, header *types.Header, chain c
 	} else if chain.Config().IsIstanbulPoSA(header.Number, header.Time) {
 		// ##CROSS: istanbul posa
 		// Validators are managed by the system contract, we don't check the votes anymore
-		if sb.config.OnNewValidatorEpoch(header.Number.Uint64()) {
+		if sb.config.GetConfig(header.Number).OnNewValidatorEpoch(header.Number.Uint64()) {
 			// Only update validator set at epoch boundaries
 			// Otherwise, keep the existing validator set from the snapshot
 			validators, signers, err := sb.Engine().ExtractValidators(header)

--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -225,8 +225,8 @@ func (s *Snapshot) UnmarshalJSON(b []byte) error {
 	s.Votes = j.Votes
 	s.Tally = j.Tally
 
-	// Setting the By function to ValidatorSortByStringFunc should be fine, as the validator do not change only the order changes
-	pp := istanbul.NewProposerPolicyByIdAndSortFunc(j.Policy, istanbul.ValidatorSortByString())
+	// Keep snapshot restores consistent with the bitset indexes used by BLS committed seals.
+	pp := istanbul.NewProposerPolicyByIdAndSortFunc(j.Policy, istanbul.ValidatorSortByByte())
 	s.ValSet = validator.NewSet(j.Validators, j.Signers, pp) // ##CROSS: bls seal
 	return nil
 }

--- a/consensus/istanbul/config.go
+++ b/consensus/istanbul/config.go
@@ -43,18 +43,18 @@ type ProposerPolicy struct {
 	registryMU *sync.Mutex         // Mutex to lock access to changes to Registry
 }
 
-// NewRoundRobinProposerPolicy returns a RoundRobin ProposerPolicy with ValidatorSortByString as default sort function
+// NewRoundRobinProposerPolicy returns a RoundRobin ProposerPolicy with ValidatorSortByByte as default sort function
 func NewRoundRobinProposerPolicy() *ProposerPolicy {
 	return NewProposerPolicy(RoundRobin)
 }
 
-// NewStickyProposerPolicy return a Sticky ProposerPolicy with ValidatorSortByString as default sort function
+// NewStickyProposerPolicy return a Sticky ProposerPolicy with ValidatorSortByByte as default sort function
 func NewStickyProposerPolicy() *ProposerPolicy {
 	return NewProposerPolicy(Sticky)
 }
 
 func NewProposerPolicy(id ProposerPolicyId) *ProposerPolicy {
-	return NewProposerPolicyByIdAndSortFunc(id, ValidatorSortByString())
+	return NewProposerPolicyByIdAndSortFunc(id, ValidatorSortByByte())
 }
 
 func NewProposerPolicyByIdAndSortFunc(id ProposerPolicyId, by ValidatorSortByFunc) *ProposerPolicy {
@@ -89,7 +89,7 @@ func (p *ProposerPolicy) UnmarshalTOML(decode func(interface{}) error) error {
 		return err
 	}
 	p.Id = pp.Id
-	p.By = ValidatorSortByString()
+	p.By = ValidatorSortByByte()
 
 	if p.registryMU == nil {
 		p.registryMU = new(sync.Mutex)

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -638,7 +638,14 @@ func (e *Engine) verifyCommittedSeals(chain consensus.ChainHeaderReader, header 
 			for _, pubkey := range pubkeys {
 				pubkeystr = append(pubkeystr, hexutil.Encode(pubkey.Marshal()))
 			}
-			log.Error("Istanbul: failed to verify aggregated seal", "sig", hexutil.Encode(sig.Marshal()), "pubkeys", pubkeystr, "proposalSeal", proposalSeal.String())
+			log.Error("Istanbul: failed to verify aggregated seal",
+				"number", header.Number.Uint64(),
+				"sig", hexutil.Encode(sig.Marshal()),
+				"proposalSeal", proposalSeal.String(),
+				"pubkeys", pubkeystr,
+				"validators", validators.List(),
+				"extra", hexutil.Encode(header.Extra),
+			)
 			return istanbul.ErrInvalidCommittedSeals
 		}
 		// ##

--- a/consensus/istanbul/validator/default_test.go
+++ b/consensus/istanbul/validator/default_test.go
@@ -17,9 +17,9 @@
 package validator
 
 import (
+	"bytes"
 	fmt "fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -62,11 +62,11 @@ func testNewValidatorSet(t *testing.T) {
 		t.FailNow()
 	}
 
-	// Check validators sorting: should be in ascending order
+	// Check validators sorting: should be in ascending byte order
 	for i := 0; i < ValCnt-1; i++ {
 		val := valSet.GetByIndex(uint64(i))
 		nextVal := valSet.GetByIndex(uint64(i + 1))
-		if strings.Compare(val.String(), nextVal.String()) >= 0 {
+		if bytes.Compare(val.Address().Bytes(), nextVal.Address().Bytes()) >= 0 {
 			t.Errorf("validator set is not sorted in ascending order")
 		}
 	}

--- a/consensus/istanbul/validator/proposerpolicy_test.go
+++ b/consensus/istanbul/validator/proposerpolicy_test.go
@@ -38,21 +38,14 @@ var (
 
 func TestProposerPolicy(t *testing.T) {
 	addressSortedByByte := []common.Address{addr6, addr4, addr1, addr3, addr5, addr2}
-	addressSortedByString := []common.Address{addr6, addr4, addr1, addr2, addr5, addr3}
 
 	pp := istanbul.NewRoundRobinProposerPolicy()
-	pp.Use(istanbul.ValidatorSortByByte())
 
 	valSet := NewSet(addrSet, nil, pp)
 	valList := valSet.List()
 
 	for i := 0; i < 6; i++ {
 		assert.Equal(t, addressSortedByByte[i].Hex(), valList[i].String(), "validatorSet not byte sorted")
-	}
-
-	pp.Use(istanbul.ValidatorSortByString())
-	for i := 0; i < 6; i++ {
-		assert.Equal(t, addressSortedByString[i].Hex(), valList[i].String(), "validatorSet not string sorted")
 	}
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1        // Major version component of the current release
 	Minor = 3        // Minor version component of the current release
-	Patch = 8        // Patch version component of the current release
+	Patch = 9        // Patch version component of the current release
 	Meta  = "stable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Summary

Fixed Inconsistency in the Validator Set sorting policy.

When reading the validator set from the snapshot, it was sorted by string. This fix changes it to sort by bytes, keeping consistency with Istanbul runtime engine.