### PR TITLE
fix: withdrawals and system tx

### DIFF
--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -1364,11 +1364,14 @@ func (e *Engine) applySystemTransaction(
 		}
 	}
 
+	nonce := state.GetNonce(msg.From)
 	gasUsed, err := applySystemMessage(msg, evm, state, header)
 	if err != nil {
 		return err
 	}
 	*txs = append(*txs, tx)
+	// Increment the nonce only after the system call succeeds
+	state.SetNonce(msg.From, nonce+1, tracing.NonceChangeEoACall)
 
 	// Update the state with pending changes.
 	var root []byte
@@ -1402,8 +1405,6 @@ func applySystemMessage(msg *core.Message, evm *vm.EVM, state vm.StateDB, header
 		state.Prepare(rules, msg.From, evm.Context.Coinbase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
 	}
 
-	nonce := state.GetNonce(msg.From)
-
 	ret, returnGas, err := evm.Call(
 		msg.From,
 		*msg.To,
@@ -1421,9 +1422,6 @@ func applySystemMessage(msg *core.Message, evm *vm.EVM, state vm.StateDB, header
 			"value", msg.Value.String(),
 		)
 	}
-
-	// Increment the nonce only after the system call succeeds
-	state.SetNonce(msg.From, nonce+1, tracing.NonceChangeEoACall)
 
 	return msg.GasLimit - returnGas, err
 }

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -1401,8 +1401,8 @@ func applySystemMessage(msg *core.Message, evm *vm.EVM, state vm.StateDB, header
 		rules := evm.ChainConfig().Rules(evm.Context.BlockNumber, evm.Context.Random != nil, evm.Context.Time)
 		state.Prepare(rules, msg.From, evm.Context.Coinbase, msg.To, vm.ActivePrecompiles(rules), msg.AccessList)
 	}
-	// Increment the nonce for the next transaction
-	state.SetNonce(msg.From, state.GetNonce(msg.From)+1, tracing.NonceChangeEoACall)
+
+	nonce := state.GetNonce(msg.From)
 
 	ret, returnGas, err := evm.Call(
 		msg.From,
@@ -1421,6 +1421,10 @@ func applySystemMessage(msg *core.Message, evm *vm.EVM, state vm.StateDB, header
 			"value", msg.Value.String(),
 		)
 	}
+
+	// Increment the nonce only after the system call succeeds
+	state.SetNonce(msg.From, nonce+1, tracing.NonceChangeEoACall)
+
 	return msg.GasLimit - returnGas, err
 }
 

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -1194,7 +1194,11 @@ func (w *worker) generateWork(params *generateParams, witness bool) *newPayloadR
 		}
 	}
 	body := types.Body{Transactions: work.txs}
-	if !w.chainConfig.IsIstanbulConsensus() { // ##CROSS: istanbul
+	if w.chainConfig.IsIstanbulConsensus() { // ##CROSS: istanbul
+		if w.chainConfig.IsCancun(work.header.Number, work.header.Time) {
+			body.Withdrawals = types.Withdrawals{}
+		}
+	} else {
 		body.Withdrawals = params.withdrawals
 	}
 	// Collect consensus-layer requests if Prague is enabled.

--- a/version/version.go
+++ b/version/version.go
@@ -19,6 +19,6 @@ package version
 const (
 	Major = 1        // Major version component of the current release
 	Minor = 3        // Minor version component of the current release
-	Patch = 10       // Patch version component of the current release
+	Patch = 11       // Patch version component of the current release
 	Meta  = "stable" // Version metadata to append to the version string
 )


### PR DESCRIPTION
## Summary

- Sets withdrawals as empty in block body on Cancun-era. (CRO-40)
- Increment nonce only after system transaction succeeds. (CRO-10)