### PR TITLE
Fix Istanbul validator byte sort policy

### DIFF
--- a/consensus/istanbul/backend/snapshot.go
+++ b/consensus/istanbul/backend/snapshot.go
@@ -225,8 +225,9 @@ func (s *Snapshot) UnmarshalJSON(b []byte) error {
 	s.Votes = j.Votes
 	s.Tally = j.Tally
 
-	// Setting the By function to ValidatorSortByStringFunc should be fine, as the validator do not change only the order changes
-	pp := istanbul.NewProposerPolicyByIdAndSortFunc(j.Policy, istanbul.ValidatorSortByString())
+	// ##CROSS: validator sort policy
+	// Validator sort policy is changed from by-string to by-byte
+	pp := istanbul.NewProposerPolicyByIdAndSortFunc(j.Policy, istanbul.ValidatorSortByByte())
 	s.ValSet = validator.NewSet(j.Validators, j.Signers, pp) // ##CROSS: bls seal
 	return nil
 }

--- a/consensus/istanbul/engine/consensus.go
+++ b/consensus/istanbul/engine/consensus.go
@@ -376,6 +376,10 @@ func (e *Engine) offlineProposers(chain consensus.ChainHeaderReader, header *typ
 	if policy == nil || policy.Id != istanbul.RoundRobin {
 		return nil, nil
 	}
+	// ##CROSS: validator sort policy
+	// Validators are sorted by byte
+	policy = istanbul.NewProposerPolicyByIdAndSortFunc(policy.Id, istanbul.ValidatorSortByByte())
+	// ##
 
 	extra, err := types.ExtractIstanbulExtra(header)
 	if err != nil {

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -1314,6 +1314,9 @@ func (e *Engine) applyReceivedSystemTransaction(
 
 	actualTx := (*systemTxs)[0]
 	if !bytes.Equal(signer.Hash(actualTx).Bytes(), expectedHash.Bytes()) {
+		expectedJson, _ := expectedTx.MarshalJSON()
+		actualJson, _ := actualTx.MarshalJSON()
+		log.Error("system tx mismatch", "expected", string(expectedJson), "actual", string(actualJson))
 		return fmt.Errorf("expected tx hash %v, get %v, nonce %d, to %s, value %s, gas %d, gasPrice %s, data %s",
 			expectedHash.String(),
 			actualTx.Hash().String(),


### PR DESCRIPTION
## Summary

This fix resolves the validator order consistency problem while calculating offline proposers.

- Restore Istanbul snapshots with the byte-sorted validator policy instead of the string-sorted policy.
- Rebuild offline proposer calculations with the byte-sorted RoundRobin policy so proposer detection stays consistent.

## Testing

Fully tested on the testbed environment.

- Deploy new nodes while operation live.
- Slash some validators and verify that the slash transaction propagates properly.