### PR TITLE
Fix: catch up audit and testnet hardfork

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -167,6 +167,10 @@ type IstanbulEngine interface {
 	// EstimateGasForSystemTxs estimates the gas cost for system transactions in the given block.
 	EstimateGasForSystemTxs(ChainHeaderReader, *types.Header) uint64
 
+	// ApplySystemTransaction re-applies a system transaction on the given EVM using consensus execution semantics.
+	// It is intended for historical state reconstruction and tracing; callers must check IsSystemTransaction beforehand.
+	ApplySystemTransaction(evm *vm.EVM, header *types.Header, tx *types.Transaction, txIndex int) error
+
 	// ValidatorsAt returns the validator addresses at the given block number.
 	ValidatorsAt(ChainHeaderReader, *types.Header) []common.Address // ##CROSS: istanbul posa
 	// ##

--- a/consensus/istanbul/backend/api.go
+++ b/consensus/istanbul/backend/api.go
@@ -46,9 +46,14 @@ type Status struct {
 	NumBlocks     uint64                 `json:"numBlocks"`
 }
 
-// NodeAddress returns the public address that is used to sign block headers in IBFT
+// NodeAddress returns the public address that is used to sign block headers before Breakpoint hardfork.
 func (api *API) NodeAddress() common.Address {
 	return api.backend.Address()
+}
+
+// SignerAddress returns the BLS public key that is used to sign block headers after Breakpoint hardfork.
+func (api *API) SignerAddress() types.BLSPublicKey {
+	return api.backend.SignerAddress()
 }
 
 // GetSignersFromBlock returns the signers and minter for a given block number, or the

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -129,6 +129,11 @@ func (sb *Backend) Address() common.Address {
 	return sb.Engine().Address()
 }
 
+// SignerAddress returns BLS public key.
+func (sb *Backend) SignerAddress() types.BLSPublicKey {
+	return types.BytesToBLSPublicKey(sb.blsSecretKey.PublicKey().Marshal())
+}
+
 // Validators implements istanbul.Backend.Validators
 func (sb *Backend) Validators(proposal istanbul.Proposal) istanbul.ValidatorSet {
 	return sb.getValidators(proposal.Number().Uint64(), proposal.Hash())

--- a/consensus/istanbul/backend/backend.go
+++ b/consensus/istanbul/backend/backend.go
@@ -131,6 +131,9 @@ func (sb *Backend) Address() common.Address {
 
 // SignerAddress returns BLS public key.
 func (sb *Backend) SignerAddress() types.BLSPublicKey {
+	if sb.blsSecretKey == nil {
+		return types.BLSPublicKey{}
+	}
 	return types.BytesToBLSPublicKey(sb.blsSecretKey.PublicKey().Marshal())
 }
 

--- a/consensus/istanbul/backend/engine.go
+++ b/consensus/istanbul/backend/engine.go
@@ -48,16 +48,25 @@ var _ consensus.Engine = (*Backend)(nil)
 // ##CROSS: consensus system contract
 var _ consensus.IstanbulEngine = (*Backend)(nil)
 
+// IsSystemTransaction checks if the transaction is a system transaction,
+// which is a legacy transaction to a system contract with gas price 0 and sender is the block proposer.
 func (sb *Backend) IsSystemTransaction(tx *types.Transaction, header *types.Header) (bool, error) {
 	return sb.Engine().IsSystemTransaction(tx, header)
 }
 
+// IsSystemContract checks if the address is a system contract.
 func (sb *Backend) IsSystemContract(to *common.Address) bool {
 	return sb.Engine().IsSystemContract(to)
 }
 
+// EstimateGasForSystemTxs estimates the gas cost for system transactions in the given block.
 func (sb *Backend) EstimateGasForSystemTxs(chain consensus.ChainHeaderReader, header *types.Header) uint64 {
 	return sb.Engine().EstimateGasForSystemTxs(chain, header)
+}
+
+// ApplySystemTransaction re-applies a system transaction using consensus execution semantics.
+func (sb *Backend) ApplySystemTransaction(evm *vm.EVM, header *types.Header, tx *types.Transaction, txIndex int) error {
+	return sb.Engine().ApplySystemTransaction(evm, header, tx, txIndex)
 }
 
 // ##

--- a/consensus/istanbul/engine/consensus_test.go
+++ b/consensus/istanbul/engine/consensus_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/ethereum/go-ethereum/triedb"
@@ -683,6 +684,9 @@ func (m *mockIstanbulEngine) EstimateGasForSystemTxs(chain consensus.ChainHeader
 }
 func (m *mockIstanbulEngine) ValidatorsAt(chain consensus.ChainHeaderReader, header *types.Header) []common.Address {
 	return append([]common.Address(nil), m.validators...)
+}
+func (m *mockIstanbulEngine) ApplySystemTransaction(evm *vm.EVM, header *types.Header, tx *types.Transaction, txIndex int) error {
+	return nil
 }
 
 // createHeaderWithIstanbulExtra creates a header with Istanbul extra data

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -24,7 +24,6 @@ import (
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/tracing"
-	"github.com/ethereum/go-ethereum/core/txpool"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -262,13 +261,8 @@ func (e *Engine) VerifyBlockProposal(chain consensus.ChainHeaderReader, block *t
 
 	// verify the header of proposed block
 	err := e.VerifyHeader(chain, block.Header(), nil, validators)
-	if err == nil || err == istanbul.ErrEmptyCommittedSeals { // ignore errEmptyCommittedSeals error because we don't have the committed seals yet
-		// ##CROSS: bad block mitigation
-		// Verify the transactions in the proposed block
-		if err := e.verifyProposalTransactions(chain, block); err != nil {
-			return 0, err
-		}
-		// ##
+	if err == nil || err == istanbul.ErrEmptyCommittedSeals {
+		// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
 		return 0, nil
 	} else if err == consensus.ErrFutureBlock {
 		return time.Until(time.Unix(int64(block.Header().Time), 0)), consensus.ErrFutureBlock
@@ -285,55 +279,6 @@ func (e *Engine) VerifyBlockProposal(chain consensus.ChainHeaderReader, block *t
 
 	return 0, err
 }
-
-// ##CROSS: bad block mitigation
-// verifyProposalTransactions carries out the basic validation of the transactions in the proposed block.
-func (e *Engine) verifyProposalTransactions(chain consensus.ChainHeaderReader, block *types.Block) error {
-	header := block.Header()
-	signer := types.MakeSigner(chain.Config(), header.Number, header.Time)
-	opts := &txpool.ValidationOptions{
-		Config: chain.Config(),
-		Accept: 0 |
-			1<<types.LegacyTxType |
-			1<<types.AccessListTxType |
-			1<<types.DynamicFeeTxType |
-			1<<types.FeeDelegatedDynamicFeeTxType |
-			1<<types.SetCodeTxType,
-		MaxSize: math.MaxUint64,
-		MinTip:  common.Big0,
-	}
-
-	var (
-		usedGas      uint64
-		seenSystemTx bool
-	)
-	for i, tx := range block.Transactions() {
-		isSystemTx, err := e.IsSystemTransaction(tx, header)
-		if err != nil {
-			return fmt.Errorf("invalid system transaction %d [%v]: %w", i, tx.Hash(), err)
-		}
-		if isSystemTx {
-			seenSystemTx = true
-			continue
-		}
-		if seenSystemTx {
-			return fmt.Errorf("normal tx %d [%v] after system transaction", i, tx.Hash())
-		}
-		if err := txpool.ValidateTransaction(tx, header, signer, opts); err != nil {
-			return fmt.Errorf("invalid transaction %d [%v]: %w", i, tx.Hash(), err)
-		}
-		if header.BaseFee != nil && chain.Config().IsLondon(header.Number) && tx.GasFeeCapIntCmp(header.BaseFee) < 0 {
-			return fmt.Errorf("invalid transaction %d [%v]: %w: maxFeePerGas %s, baseFee %s", i, tx.Hash(), core.ErrFeeCapTooLow, tx.GasFeeCap(), header.BaseFee)
-		}
-		if tx.Gas() > header.GasLimit-usedGas {
-			return fmt.Errorf("transactions gas exceeds block gas limit at tx %d [%v]: used %d, tx gas %d, limit %d", i, tx.Hash(), usedGas, tx.Gas(), header.GasLimit)
-		}
-		usedGas += tx.Gas()
-	}
-	return nil
-}
-
-// ##
 
 // VerifyHeader verifies the header of the block.
 func (e *Engine) VerifyHeader(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header, validators istanbul.ValidatorSet) error {

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -1345,16 +1345,53 @@ func (e *Engine) applySystemTransaction(
 	receipts *[]*types.Receipt,
 	usedGas *uint64,
 	tracer *tracing.Hooks,
-) (err error) {
-	state.SetTxContext(tx.Hash(), len(*txs))
-
+) error {
 	context := core.NewEVMBlockContext(header, chainContext, &author)
 	evm := vm.NewEVM(context, state, chainContext.Config(), vm.Config{Tracer: tracer})
-	evm.SetTxContext(core.NewEVMTxContext(msg))
-	evm.StateDB.AddAddressToAccessList(*msg.To)
 
-	var receipt *types.Receipt
-	if tracer != nil {
+	receipt, err := executeSystemTransaction(evm, msg, tx, header, len(*txs), usedGas)
+	if err != nil {
+		return err
+	}
+	*txs = append(*txs, tx)
+	*receipts = append(*receipts, receipt)
+	return nil
+}
+
+// ApplySystemTransaction re-applies a system transaction on the given EVM using consensus execution semantics.
+// It is intended for historical state reconstruction and tracing; callers must check IsSystemTransaction beforehand.
+func (e *Engine) ApplySystemTransaction(evm *vm.EVM, header *types.Header, tx *types.Transaction, txIndex int) error {
+	from, err := types.Sender(types.LatestSignerForChainID(tx.ChainId()), tx)
+	if err != nil {
+		return err
+	}
+	// The transaction was validated against the expected message at import time,
+	// so the message can be reconstructed from the transaction fields directly.
+	msg := &core.Message{
+		From:     from,
+		To:       tx.To(),
+		GasLimit: tx.Gas(),
+		GasPrice: tx.GasPrice(),
+		Value:    tx.Value(),
+		Data:     tx.Data(),
+	}
+	// Used gas of the block is not tracked during replay.
+	// The receipt built for tracer hooks reports only the gas used by this call.
+	var usedGas uint64
+	_, err = executeSystemTransaction(evm, msg, tx, header, txIndex, &usedGas)
+	return err
+}
+
+// executeSystemTransaction executes a system transaction message on the given EVM with consensus execution semantics.
+// The gas used is added to usedGas and a receipt built from it is returned.
+// This is the single execution path shared by block finalization and historical replay/tracing.
+func executeSystemTransaction(evm *vm.EVM, msg *core.Message, tx *types.Transaction, header *types.Header, txIndex int, usedGas *uint64) (receipt *types.Receipt, err error) {
+	state := evm.StateDB
+	state.SetTxContext(tx.Hash(), txIndex)
+	evm.SetTxContext(core.NewEVMTxContext(msg))
+	state.AddAddressToAccessList(*msg.To)
+
+	if tracer := evm.Config.Tracer; tracer != nil {
 		onSystemCallStart(tracer, evm.GetVMContext())
 		if tracer.OnTxStart != nil {
 			tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
@@ -1370,10 +1407,9 @@ func (e *Engine) applySystemTransaction(
 	nonce := state.GetNonce(msg.From)
 	gasUsed, err := applySystemMessage(msg, evm, state, header)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	*txs = append(*txs, tx)
-	// Increment the nonce only after the system call succeeds
+	// Increment the nonce only after the system call succeeds.
 	state.SetNonce(msg.From, nonce+1, tracing.NonceChangeEoACall)
 
 	// Update the state with pending changes.
@@ -1397,8 +1433,7 @@ func (e *Engine) applySystemTransaction(
 	receipt.BlockHash = header.Hash()
 	receipt.BlockNumber = header.Number
 	receipt.TransactionIndex = uint(state.TxIndex())
-	*receipts = append(*receipts, receipt)
-	return
+	return receipt, nil
 }
 
 func applySystemMessage(msg *core.Message, evm *vm.EVM, state vm.StateDB, header *types.Header) (uint64, error) {

--- a/consensus/istanbul/engine/engine.go
+++ b/consensus/istanbul/engine/engine.go
@@ -263,6 +263,9 @@ func (e *Engine) VerifyBlockProposal(chain consensus.ChainHeaderReader, block *t
 	err := e.VerifyHeader(chain, block.Header(), nil, validators)
 	if err == nil || err == istanbul.ErrEmptyCommittedSeals {
 		// ignore errEmptyCommittedSeals error because we don't have the committed seals yet
+		// TODO e.verifyBlockProposalTransactions() should implemented again.
+		// Old verification was too strict and caused liveness problem,
+		// so it was removed for safety temporarily.
 		return 0, nil
 	} else if err == consensus.ErrFutureBlock {
 		return time.Until(time.Unix(int64(block.Header().Time), 0)), consensus.ErrFutureBlock

--- a/consensus/istanbul/engine/engine_test.go
+++ b/consensus/istanbul/engine/engine_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"bytes"
+	"math"
 	"math/big"
 	"testing"
 
@@ -11,9 +12,16 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/istanbul"
 	"github.com/ethereum/go-ethereum/consensus/istanbul/validator"
 	"github.com/ethereum/go-ethereum/contracts"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/core/state"
+	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
+	"github.com/ethereum/go-ethereum/triedb"
+	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -67,6 +75,83 @@ func TestIsSystemTransaction(t *testing.T) {
 	isSystemTx, err = IsSystemTransaction(dynamicFeeTx, header)
 	require.NoError(t, err)
 	assert.False(t, isSystemTx)
+}
+
+// newTestStateDB creates an empty in-memory state database for testing.
+func newTestStateDB(t *testing.T) *state.StateDB {
+	t.Helper()
+	memdb := rawdb.NewMemoryDatabase()
+	tdb := triedb.NewDatabase(memdb, nil)
+	sdb := state.NewDatabase(tdb, nil)
+	statedb, err := state.New(types.EmptyRootHash, sdb)
+	require.NoError(t, err)
+	return statedb
+}
+
+// TestApplySystemTransaction verifies that replaying a system transaction keeps
+// consensus execution semantics and results in the same state as the consensus path.
+func TestApplySystemTransaction(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	require.NoError(t, err)
+
+	var (
+		sender      = crypto.PubkeyToAddress(key.PublicKey)
+		to          = contracts.ValidatorSetAddr
+		value       = big.NewInt(100)
+		data        = []byte("system call data")
+		chainConfig = params.TestChainConfig
+		signer      = types.LatestSignerForChainID(chainConfig.ChainID)
+		funds       = uint256.NewInt(1_000_000)
+	)
+	header := &types.Header{
+		Number:     big.NewInt(100),
+		Coinbase:   sender,
+		BaseFee:    big.NewInt(1_000_000_000), // non-zero to prove no fee is charged
+		GasLimit:   10_000_000,
+		Difficulty: big.NewInt(0),
+		Time:       1_000_000_000,
+	}
+	tx := types.MustSignNewTx(key, signer, &types.LegacyTx{
+		Nonce:    0,
+		GasPrice: big.NewInt(0),
+		Gas:      math.MaxUint64 / 2,
+		To:       &to,
+		Value:    value,
+		Data:     data,
+	})
+	isSystemTx, err := IsSystemTransaction(tx, header)
+	require.NoError(t, err)
+	require.True(t, isSystemTx)
+
+	// Replay the transaction with consensus execution semantics
+	replayDB := newTestStateDB(t)
+	replayDB.AddBalance(sender, funds, tracing.BalanceChangeUnspecified)
+	blockCtx := core.NewEVMBlockContext(header, &chainMock{config: chainConfig}, &header.Coinbase)
+	evm := vm.NewEVM(blockCtx, replayDB, chainConfig, vm.Config{})
+
+	engine := &Engine{}
+	require.NoError(t, engine.ApplySystemTransaction(evm, header, tx, 0))
+
+	// No intrinsic gas or fee is charged; only the value is transferred
+	assert.Equal(t, uint64(1), replayDB.GetNonce(sender))
+	assert.Equal(t, uint256.NewInt(100), replayDB.GetBalance(to))
+	assert.Equal(t, new(uint256.Int).Sub(funds, uint256.NewInt(100)), replayDB.GetBalance(sender))
+
+	// Apply the same transaction through the consensus path and compare the state
+	consensusDB := newTestStateDB(t)
+	consensusDB.AddBalance(sender, funds, tracing.BalanceChangeUnspecified)
+	var (
+		txs      []*types.Transaction
+		receipts []*types.Receipt
+		usedGas  uint64
+	)
+	msg := newSystemMessage(sender, to, data, value)
+	err = engine.applySystemTransaction(msg, tx, consensusDB, header, &chainMock{config: chainConfig}, header.Coinbase, &txs, &receipts, &usedGas, nil)
+	require.NoError(t, err)
+
+	// Both state should be equal
+	deleteEmptyObjects := chainConfig.IsEIP158(header.Number)
+	assert.Equal(t, consensusDB.IntermediateRoot(deleteEmptyObjects), replayDB.IntermediateRoot(deleteEmptyObjects))
 }
 
 // ##

--- a/contracts/upgrade.go
+++ b/contracts/upgrade.go
@@ -2,6 +2,7 @@ package contracts
 
 import (
 	"fmt"
+	"math/big"
 	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -223,6 +224,55 @@ func init() {
 			// ##
 		},
 	}
+	// Contract patches for testnet
+	upgrades[forks.BreakpointAlpha] = make(map[uint64]*Upgrade)
+	upgrades[forks.BreakpointAlpha][params.ZoneZeroChainConfig.ChainID.Uint64()] = &Upgrade{
+		UpgradeName: forks.Breakpoint.String(),
+		Configs: []*UpgradeConfig{
+			// ##CROSS: consensus system contract
+			{
+				Name:         "ValidatorSetImpl",
+				Commit:       "5cbc608bd77ef186120308ec8219a016197efba2",
+				ContractAddr: ValidatorSetImplAddr,
+				Code:         breakpoint.ValidatorSetMetaData.BinRuntime,
+				Storage: map[common.Hash]common.Hash{
+					initializableSlot: initializedData,
+				},
+			},
+			{
+				Name:         "ValidatorSetProxy",
+				Commit:       "5cbc608bd77ef186120308ec8219a016197efba2",
+				ContractAddr: ValidatorSetAddr,
+				Code:         predeploy.ERC1967ProxyCode,
+				Storage: map[common.Hash]common.Hash{
+					implementationSlot: common.BytesToHash(ValidatorSetImplAddr.Bytes()),
+					common.HexToHash("0x86f0e39a3c4d21deb4b9249c3b1ec8d10355c59608a22092a826f5aa57331300"): common.BytesToHash(params.ZoneZeroPoSAConfig.Admin.Bytes()),
+				},
+			},
+			{
+				Name:         "ValidatorSlashImpl",
+				Commit:       "5cbc608bd77ef186120308ec8219a016197efba2",
+				ContractAddr: ValidatorSlashImplAddr,
+				Code:         breakpoint.ValidatorSlashMetaData.BinRuntime,
+				Storage: map[common.Hash]common.Hash{
+					initializableSlot: initializedData,
+				},
+			},
+			{
+				Name:         "ValidatorSlashProxy",
+				Commit:       "5cbc608bd77ef186120308ec8219a016197efba2",
+				ContractAddr: ValidatorSlashAddr,
+				Code:         predeploy.ERC1967ProxyCode,
+				Storage: map[common.Hash]common.Hash{
+					implementationSlot:      common.BytesToHash(ValidatorSlashImplAddr.Bytes()),
+					common.HexToHash("0x4"): common.BytesToHash(new(big.Int).SetUint64(4).Bytes()),
+					common.HexToHash("0x5"): common.BytesToHash(new(big.Int).SetUint64(50).Bytes()),
+					common.HexToHash("0x86f0e39a3c4d21deb4b9249c3b1ec8d10355c59608a22092a826f5aa57331300"): common.BytesToHash(params.ZoneZeroPoSAConfig.Admin.Bytes()),
+				},
+			},
+			// ##
+		},
+	}
 }
 
 func getUpgrade(fork forks.Fork, chainID uint64) *Upgrade {
@@ -246,6 +296,10 @@ func TryUpdateSystemContract(config *params.ChainConfig, header *types.Header, l
 	}
 	if config.IsOnBreakpoint(header.Number, lastBlockTime, header.Time) {
 		applySystemContractUpgrade(getUpgrade(forks.Breakpoint, chainID), header, statedb, writeLog)
+		upgraded = true
+	}
+	if config.IsOnBreakpointAlpha(header.Number, lastBlockTime, header.Time) {
+		applySystemContractUpgrade(getUpgrade(forks.BreakpointAlpha, chainID), header, statedb, writeLog)
 		upgraded = true
 	}
 	return

--- a/contracts/upgrade.go
+++ b/contracts/upgrade.go
@@ -227,7 +227,7 @@ func init() {
 	// Contract patches for testnet
 	upgrades[forks.BreakpointAlpha] = make(map[uint64]*Upgrade)
 	upgrades[forks.BreakpointAlpha][params.ZoneZeroChainConfig.ChainID.Uint64()] = &Upgrade{
-		UpgradeName: forks.Breakpoint.String(),
+		UpgradeName: forks.BreakpointAlpha.String(),
 		Configs: []*UpgradeConfig{
 			// ##CROSS: consensus system contract
 			{

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -255,21 +255,32 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		checkedSystemTx bool
 	)
 	for idx, tx := range block.Transactions() {
-		// ##CROSS: contract upgrade
+		// ##CROSS: consensus system tx
+		var isSystemTx bool
+		if eth.istanbul != nil {
+			isSystemTx, _ = eth.istanbul.IsSystemTransaction(tx, block.Header())
+		}
 		// Upgrade system contract before the first system transaction if the block is at upgrade point.
-		if !checkedSystemTx {
-			if eth.istanbul != nil {
-				if isSystemTx, _ := eth.istanbul.IsSystemTransaction(tx, block.Header()); isSystemTx {
-					_ = contracts.TryUpdateSystemContract(eth.blockchain.Config(), block.Header(), parent.Time(), statedb, false)
-					checkedSystemTx = true
-				}
-			}
+		if isSystemTx && !checkedSystemTx {
+			_ = contracts.TryUpdateSystemContract(eth.blockchain.Config(), block.Header(), parent.Time(), statedb, false)
+			checkedSystemTx = true
 		}
 		// ##
 
 		if idx == txIndex {
 			return tx, context, statedb, release, nil
 		}
+
+		// ##CROSS: consensus system tx
+		// System transactions are replayed through the consensus execution path.
+		if isSystemTx {
+			if err := eth.istanbul.ApplySystemTransaction(evm, block.Header(), tx, idx); err != nil {
+				return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("system transaction %#x failed: %v", tx.Hash(), err)
+			}
+			continue
+		}
+		// ##
+
 		// Assemble the transaction call message and return if the requested offset
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -275,7 +275,7 @@ func (eth *Ethereum) stateAtTransaction(ctx context.Context, block *types.Block,
 		// System transactions are replayed through the consensus execution path.
 		if isSystemTx {
 			if err := eth.istanbul.ApplySystemTransaction(evm, block.Header(), tx, idx); err != nil {
-				return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("system transaction %#x failed: %v", tx.Hash(), err)
+				return nil, vm.BlockContext{}, nil, nil, fmt.Errorf("system transaction %#x failed: %w", tx.Hash(), err)
 			}
 			continue
 		}

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -276,11 +276,9 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 				)
 				// Trace all the transactions contained within
 				for i, tx := range task.block.Transactions() {
-					// ##CROSS: contract upgrade
-					// Upgrade system contract before the first system transaction if the block is at upgrade point.
-					if !checkedSystemTx {
-						checkedSystemTx = api.tryUpdateSystemContract(tx, task.block.Header(), task.parent.Time(), task.statedb)
-					}
+					// ##CROSS: consensus system tx
+					// Upgrade system contracts on the first system transaction if the block is at upgrade point.
+					api.checkSystemTransaction(tx, task.block.Header(), task.parent.Time(), task.statedb, &checkedSystemTx)
 					// ##
 
 					msg, _ := core.TransactionToMessage(tx, signer, task.block.BaseFee())
@@ -290,7 +288,7 @@ func (api *API) traceChain(start, end *types.Block, config *TraceConfig, closed 
 						TxIndex:     i,
 						TxHash:      tx.Hash(),
 					}
-					res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, task.statedb, config, nil)
+					res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, task.block.Header(), task.statedb, config, nil)
 					if err != nil {
 						task.results[i] = &txTraceResult{TxHash: tx.Hash(), Error: err.Error()}
 						log.Warn("Tracing failed", "hash", tx.Hash(), "block", task.block.NumberU64(), "err", err)
@@ -561,10 +559,14 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			return nil, err
 		}
 
-		// ##CROSS: contract upgrade
-		// Upgrade system contract before the first system transaction if the block is at upgrade point.
-		if !checkedSystemTx {
-			checkedSystemTx = api.tryUpdateSystemContract(tx, block.Header(), parent.Time(), statedb)
+		// ##CROSS: consensus system tx
+		if api.checkSystemTransaction(tx, block.Header(), parent.Time(), statedb, &checkedSystemTx) {
+			if err := api.applySystemTransaction(evm, block.Header(), tx, i); err != nil {
+				log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
+				return roots, nil
+			}
+			roots = append(roots, statedb.IntermediateRoot(deleteEmptyObjects))
+			continue
 		}
 		// ##
 
@@ -646,11 +648,9 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		checkedSystemTx bool
 	)
 	for i, tx := range txs {
-		// ##CROSS: contract upgrade
-		// Upgrade system contract before the first system transaction if the block is at upgrade point.
-		if !checkedSystemTx {
-			checkedSystemTx = api.tryUpdateSystemContract(tx, block.Header(), parent.Time(), statedb)
-		}
+		// ##CROSS: consensus system tx
+		// Upgrade system contracts on the first system transaction if the block is at upgrade point.
+		api.checkSystemTransaction(tx, block.Header(), parent.Time(), statedb, &checkedSystemTx)
 		// ##
 
 		// Generate the next state snapshot fast without tracing
@@ -661,7 +661,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 			TxIndex:     i,
 			TxHash:      tx.Hash(),
 		}
-		res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, statedb, config, nil)
+		res, err := api.traceTx(ctx, tx, msg, txctx, blockCtx, block.Header(), statedb, config, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -705,7 +705,7 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 				// concurrent use.
 				// See: https://github.com/ethereum/go-ethereum/issues/29114
 				blockCtx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
-				res, err := api.traceTx(ctx, txs[task.index], msg, txctx, blockCtx, task.statedb, config, nil)
+				res, err := api.traceTx(ctx, txs[task.index], msg, txctx, blockCtx, block.Header(), task.statedb, config, nil)
 				if err != nil {
 					results[task.index] = &txTraceResult{TxHash: txs[task.index].Hash(), Error: err.Error()}
 					continue
@@ -730,11 +730,9 @@ func (api *API) traceBlockParallel(ctx context.Context, block *types.Block, stat
 
 txloop:
 	for i, tx := range txs {
-		// ##CROSS: contract upgrade
-		// Upgrade system contract before the first system transaction if the block is at upgrade point.
-		if !checkedSystemTx {
-			checkedSystemTx = api.tryUpdateSystemContract(tx, block.Header(), parent.Time(), statedb)
-		}
+		// ##CROSS: consensus system tx
+		// Detect system transactions and upgrade system contracts on the first one if the block is at upgrade point.
+		isSystemTx := api.checkSystemTransaction(tx, block.Header(), parent.Time(), statedb, &checkedSystemTx)
 		// ##
 
 		// Send the trace task over for execution
@@ -745,6 +743,16 @@ txloop:
 			break txloop
 		case jobs <- task:
 		}
+
+		// ##CROSS: consensus system tx
+		if isSystemTx {
+			if err := api.applySystemTransaction(evm, block.Header(), tx, i); err != nil {
+				failed = err
+				break txloop
+			}
+			continue
+		}
+		// ##
 
 		// Generate the next state snapshot fast without tracing
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
@@ -832,15 +840,23 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		core.ProcessParentBlockHash(block.ParentHash(), evm)
 	}
 	for i, tx := range block.Transactions() {
-		// ##CROSS: contract upgrade
-		if !checkedSystemTx {
-			checkedSystemTx = api.tryUpdateSystemContract(tx, block.Header(), parent.Time(), statedb)
-		}
+		// ##CROSS: consensus system tx
+		// Detect system transactions and upgrade system contracts on the first one if the block is at upgrade point.
+		isSystemTx := api.checkSystemTransaction(tx, block.Header(), parent.Time(), statedb, &checkedSystemTx)
 		// ##
 
 		// Prepare the transaction for un-traced execution
 		msg, _ := core.TransactionToMessage(tx, signer, block.BaseFee())
 		if txHash != (common.Hash{}) && tx.Hash() != txHash {
+			// ##CROSS: consensus system tx
+			if isSystemTx {
+				if err := api.applySystemTransaction(evm, block.Header(), tx, i); err != nil {
+					return dumps, err
+				}
+				continue
+			}
+			// ##
+
 			// Process the tx to update state, but don't trace it.
 			_, err := core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
 			if err != nil {
@@ -874,10 +890,16 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		)
 		// Execute the transaction and flush any traces to disk
 		statedb.SetTxContext(tx.Hash(), i)
-		if tracer.OnTxStart != nil {
-			tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
+		// ##CROSS: consensus system tx
+		if isSystemTx {
+			err = api.applySystemTransaction(evm, block.Header(), tx, i)
+		} else {
+			if tracer.OnTxStart != nil {
+				tracer.OnTxStart(evm.GetVMContext(), tx, msg.From)
+			}
+			_, err = core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
 		}
-		_, err = core.ApplyMessage(evm, msg, new(core.GasPool).AddGas(msg.GasLimit))
+		// ##
 		if writer != nil {
 			writer.Flush()
 		}
@@ -951,7 +973,7 @@ func (api *API) TraceTransaction(ctx context.Context, hash common.Hash, config *
 		TxIndex:     int(index),
 		TxHash:      hash,
 	}
-	return api.traceTx(ctx, tx, msg, txctx, vmctx, statedb, config, nil)
+	return api.traceTx(ctx, tx, msg, txctx, vmctx, block.Header(), statedb, config, nil)
 }
 
 // TraceCall lets you trace a given eth_call. It collects the structured logs
@@ -1037,13 +1059,15 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	if config != nil {
 		traceConfig = &config.TraceConfig
 	}
-	return api.traceTx(ctx, tx, msg, new(Context), vmctx, statedb, traceConfig, precompiles)
+	// Don't pass the header; always traced as regular messages.
+	return api.traceTx(ctx, tx, msg, new(Context), vmctx, nil, statedb, traceConfig, precompiles)
 }
 
 // traceTx configures a new tracer according to the provided configuration, and
 // executes the given message in the provided environment. The return value will
 // be tracer dependent.
-func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *core.Message, txctx *Context, vmctx vm.BlockContext, statedb *state.StateDB, config *TraceConfig, precompiles vm.PrecompiledContracts) (interface{}, error) {
+// If header is given, it tries to handle the system transaction.
+func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *core.Message, txctx *Context, vmctx vm.BlockContext, header *types.Header, statedb *state.StateDB, config *TraceConfig, precompiles vm.PrecompiledContracts) (interface{}, error) {
 	var (
 		tracer  *Tracer
 		err     error
@@ -1089,6 +1113,20 @@ func (api *API) traceTx(ctx context.Context, tx *types.Transaction, message *cor
 		}
 	}()
 	defer cancel()
+
+	// ##CROSS: consensus system tx
+	// If it is the system transaction, execute through the consensus path.
+	if header != nil {
+		if ie := consensus.ToIstanbulEngine(api.backend.Engine()); ie != nil {
+			if isSystemTx, _ := ie.IsSystemTransaction(tx, header); isSystemTx {
+				if err := ie.ApplySystemTransaction(evm, header, tx, txctx.TxIndex); err != nil {
+					return nil, fmt.Errorf("tracing failed: %w", err)
+				}
+				return tracer.GetResult()
+			}
+		}
+	}
+	// ##
 
 	// Call Prepare to clear out the statedb access list
 	statedb.SetTxContext(txctx.TxHash, txctx.TxIndex)
@@ -1163,15 +1201,30 @@ func overrideConfig(original *params.ChainConfig, override *params.ChainConfig) 
 	return copy, canon
 }
 
-// ##CROSS: contract upgrade
-func (api *API) tryUpdateSystemContract(tx *types.Transaction, header *types.Header, parentTime uint64, statedb *state.StateDB) bool {
-	if ie := consensus.ToIstanbulEngine(api.backend.Engine()); ie != nil {
-		if isSystemTx, _ := ie.IsSystemTransaction(tx, header); isSystemTx {
-			_ = contracts.TryUpdateSystemContract(api.backend.ChainConfig(), header, parentTime, statedb, false)
-			return true
-		}
+// ##CROSS: consensus system tx
+
+// checkSystemTransaction reports whether tx is a system transaction.
+// On the first system transaction of a block, it also upgrades the system contracts if the block is at an upgrade point.
+func (api *API) checkSystemTransaction(tx *types.Transaction, header *types.Header, parentTime uint64, statedb *state.StateDB, checkedSystemTx *bool) bool {
+	ie := consensus.ToIstanbulEngine(api.backend.Engine())
+	if ie == nil {
+		return false
 	}
-	return false
+	isSystemTx, _ := ie.IsSystemTransaction(tx, header)
+	if isSystemTx && !*checkedSystemTx {
+		_ = contracts.TryUpdateSystemContract(api.backend.ChainConfig(), header, parentTime, statedb, false)
+		*checkedSystemTx = true
+	}
+	return isSystemTx
+}
+
+// applySystemTransaction re-applies a system transaction with consensus execution semantics.
+func (api *API) applySystemTransaction(evm *vm.EVM, header *types.Header, tx *types.Transaction, txIndex int) error {
+	ie := consensus.ToIstanbulEngine(api.backend.Engine())
+	if ie == nil {
+		return errors.New("system transaction replay requires an istanbul engine")
+	}
+	return ie.ApplySystemTransaction(evm, header, tx, txIndex)
 }
 
 // ##

--- a/internal/web3ext/web3ext.go
+++ b/internal/web3ext/web3ext.go
@@ -851,6 +851,10 @@ web3._extend({
 			name: 'nodeAddress',
 			getter: 'istanbul_nodeAddress'
 		}),
+		new web3._extend.Property({
+			name: 'signerAddress',
+			getter: 'istanbul_signerAddress'
+		}),
 	]
 });
 `

--- a/params/config.go
+++ b/params/config.go
@@ -112,6 +112,7 @@ var (
 		CancunTime:              newUint64(1778814000), // 2026-05-15 03:00:00 UTC
 		PragueTime:              newUint64(1778814000),
 		BreakpointTime:          newUint64(1778814000), // ##CROSS: fork breakpoint
+		BreakpointAlphaTime:     newUint64(1781240400), // ##CROSS: fork breakpoint
 		OsakaTime:               nil,
 		VerkleTime:              nil,
 		BlobScheduleConfig: &BlobScheduleConfig{
@@ -611,13 +612,14 @@ type ChainConfig struct {
 
 	// Fork scheduling was switched from blocks to timestamps here
 
-	ShanghaiTime   *uint64 `json:"shanghaiTime,omitempty"`   // Shanghai switch time (nil = no fork, 0 = already on shanghai)
-	AdventureTime  *uint64 `json:"adventureTime,omitempty"`  // Adventure switch time (nil = no fork, 0 = already on adventure) ##CROSS: fork adventure
-	CancunTime     *uint64 `json:"cancunTime,omitempty"`     // Cancun switch time (nil = no fork, 0 = already on cancun)
-	PragueTime     *uint64 `json:"pragueTime,omitempty"`     // Prague switch time (nil = no fork, 0 = already on prague)
-	BreakpointTime *uint64 `json:"breakpointTime,omitempty"` // Breakpoint switch time (nil = no fork, 0 = already on breakpoint) ##CROSS: fork breakpoint
-	OsakaTime      *uint64 `json:"osakaTime,omitempty"`      // Osaka switch time (nil = no fork, 0 = already on osaka)
-	VerkleTime     *uint64 `json:"verkleTime,omitempty"`     // Verkle switch time (nil = no fork, 0 = already on verkle)
+	ShanghaiTime        *uint64 `json:"shanghaiTime,omitempty"`        // Shanghai switch time (nil = no fork, 0 = already on shanghai)
+	AdventureTime       *uint64 `json:"adventureTime,omitempty"`       // Adventure switch time (nil = no fork, 0 = already on adventure) ##CROSS: fork adventure
+	CancunTime          *uint64 `json:"cancunTime,omitempty"`          // Cancun switch time (nil = no fork, 0 = already on cancun)
+	PragueTime          *uint64 `json:"pragueTime,omitempty"`          // Prague switch time (nil = no fork, 0 = already on prague)
+	BreakpointTime      *uint64 `json:"breakpointTime,omitempty"`      // Breakpoint switch time (nil = no fork, 0 = already on breakpoint) ##CROSS: fork breakpoint
+	BreakpointAlphaTime *uint64 `json:"breakpointAlphaTime,omitempty"` // BreakpointAlpha switch time (nil = no fork, 0 = already on breakpoint-alpha) ##CROSS: fork breakpoint
+	OsakaTime           *uint64 `json:"osakaTime,omitempty"`           // Osaka switch time (nil = no fork, 0 = already on osaka)
+	VerkleTime          *uint64 `json:"verkleTime,omitempty"`          // Verkle switch time (nil = no fork, 0 = already on verkle)
 
 	// TerminalTotalDifficulty is the amount of total difficulty reached by
 	// the network that triggers the consensus upgrade.
@@ -711,6 +713,9 @@ func (c *ChainConfig) Description() string {
 	// ##CROSS: fork breakpoint
 	if c.BreakpointTime != nil {
 		banner += printFork("Breakpoint", c.BreakpointTime)
+	}
+	if c.BreakpointAlphaTime != nil {
+		banner += printFork("BreakpointAlpha", c.BreakpointAlphaTime)
 	}
 	// ##
 	if c.OsakaTime != nil {
@@ -870,6 +875,20 @@ func (c *ChainConfig) IsOnBreakpoint(currentBlockNumber *big.Int, lastBlockTime 
 		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
 	}
 	return !c.IsBreakpoint(lastBlockNumber, lastBlockTime) && c.IsBreakpoint(currentBlockNumber, currentBlockTime)
+}
+
+// IsBreakpointAlpha returns whether time is either equal to the BreakpointAlpha fork time or greater.
+func (c *ChainConfig) IsBreakpointAlpha(num *big.Int, time uint64) bool {
+	return c.IsLondon(num) && isTimestampForked(c.BreakpointAlphaTime, time)
+}
+
+// IsOnBreakpointAlpha returns whether currentBlockTime is either equal to the BreakpointAlpha fork time or greater firstly.
+func (c *ChainConfig) IsOnBreakpointAlpha(currentBlockNumber *big.Int, lastBlockTime uint64, currentBlockTime uint64) bool {
+	lastBlockNumber := new(big.Int)
+	if currentBlockNumber.Cmp(big.NewInt(1)) >= 0 {
+		lastBlockNumber.Sub(currentBlockNumber, big.NewInt(1))
+	}
+	return !c.IsBreakpointAlpha(lastBlockNumber, lastBlockTime) && c.IsBreakpointAlpha(currentBlockNumber, currentBlockTime)
 }
 
 // ##
@@ -1132,6 +1151,9 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	// ##CROSS: fork breakpoint
 	if isForkTimestampIncompatible(c.BreakpointTime, newcfg.BreakpointTime, headTimestamp) {
 		return newTimestampCompatError("Breakpoint fork timestamp", c.BreakpointTime, newcfg.BreakpointTime)
+	}
+	if isForkTimestampIncompatible(c.BreakpointAlphaTime, newcfg.BreakpointAlphaTime, headTimestamp) {
+		return newTimestampCompatError("BreakpointAlpha fork timestamp", c.BreakpointAlphaTime, newcfg.BreakpointAlphaTime)
 	}
 	// ##
 	if isForkTimestampIncompatible(c.OsakaTime, newcfg.OsakaTime, headTimestamp) {

--- a/params/forks/forks.go
+++ b/params/forks/forks.go
@@ -40,7 +40,8 @@ const (
 	Adventure // ##CROSS: fork adventure
 	Cancun
 	Prague
-	Breakpoint // ##CROSS: fork breakpoint
+	Breakpoint      // ##CROSS: fork breakpoint
+	BreakpointAlpha // ##CROSS: fork breakpoint
 	Osaka
 )
 
@@ -74,6 +75,7 @@ var forkToString = map[Fork]string{
 	Adventure:        "Adventure", // ##CROSS: fork adventure
 	Cancun:           "Cancun",
 	Prague:           "Prague",
-	Breakpoint:       "Breakpoint", // ##CROSS: fork breakpoint
+	Breakpoint:       "Breakpoint",      // ##CROSS: fork breakpoint
+	BreakpointAlpha:  "BreakpointAlpha", // ##CROSS: fork breakpoint
 	Osaka:            "Osaka",
 }


### PR DESCRIPTION
## Summary

- Remove strict Istanbul proposal transaction pre-validation to avoid liveness issues while keeping header verification intact.
- Rework state access and tracing paths to replay system transactions through Istanbul consensus execution semantics.
- Apply system contract upgrades before the first system transaction during historical replay/tracing.
- Add `istanbul_signerAddress` / `istanbul.signerAddress` to expose the BLS signer public key used after Breakpoint.
- Add `BreakpointAlpha` fork for testnet update.

## Notes

The proposal transaction verification logic is intentionally disabled temporarily because the previous txpool-based validation was too strict for proposal handling.
