### PR TITLE
add --dev.noposa flag to run Istanbul chains in pre-PoSA mode

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -142,6 +142,7 @@ var (
 		utils.DeveloperFlag,
 		utils.DeveloperGasLimitFlag,
 		utils.DeveloperPeriodFlag,
+		utils.DeveloperNoPoSAFlag, // ##CROSS: istanbul posa
 		utils.VMEnableDebugFlag,
 		utils.VMTraceFlag,
 		utils.VMTraceJsonConfigFlag,

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -2012,21 +2012,29 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 	}
 	// ##CROSS: istanbul posa
-	// --dev.noposa runs the chain in pre-PoSA mode by clearing the Istanbul PoSA
-	// config. This avoids the PoSA system-contract bootstrap (which cannot run on a
-	// fresh chain whose genesis predates the Breakpoint fork). The config is cloned
-	// so the shared package-level default is not mutated. Consensus-affecting: only
-	// for local dev/test chains, not for joining a live PoSA network.
+	// --dev.noposa runs a chain in pre-PoSA mode by clearing the Istanbul PoSA
+	// config, avoiding the PoSA system-contract bootstrap that cannot run on a fresh
+	// chain whose genesis predates the Breakpoint fork. It is a local dev/test
+	// convenience and must NEVER change consensus on an official or already-running
+	// chain, so it is honored ONLY for a fresh datadir on a non-official network. In
+	// every other case it is ignored and the node follows the genesis config. The
+	// config is cloned so the shared package-level default is not mutated.
 	if ctx.Bool(DeveloperNoPoSAFlag.Name) {
-		if cfg.Genesis != nil && cfg.Genesis.Config != nil && cfg.Genesis.Config.Istanbul != nil && cfg.Genesis.Config.Istanbul.PoSA != nil {
+		switch {
+		case cfg.Genesis == nil || cfg.Genesis.Config == nil || cfg.Genesis.Config.Istanbul == nil || cfg.Genesis.Config.Istanbul.PoSA == nil:
+			log.Warn("--dev.noposa ignored: chain has no Istanbul PoSA config to disable")
+		case cfg.Genesis.Config.ChainID.Cmp(params.CrossChainConfig.ChainID) == 0 || cfg.Genesis.Config.ChainID.Cmp(params.ZoneZeroChainConfig.ChainID) == 0:
+			// Never disable PoSA on the official Cross mainnet or ZoneZero testnet.
+			log.Warn("--dev.noposa ignored on an official network; following the genesis config", "chainid", cfg.Genesis.Config.ChainID)
+		case rawdb.PreexistingDatabase(stack.ResolvePath("chaindata")) != "":
+			log.Warn("--dev.noposa ignored: chaindata already initialized; following the stored genesis config")
+		default:
 			cfgCopy := *cfg.Genesis.Config
 			istCopy := *cfg.Genesis.Config.Istanbul
 			istCopy.PoSA = nil
 			cfgCopy.Istanbul = &istCopy
 			cfg.Genesis.Config = &cfgCopy
 			log.Warn("Istanbul PoSA disabled via --dev.noposa; running in pre-PoSA mode")
-		} else {
-			log.Warn("--dev.noposa set but Istanbul PoSA is not configured for this chain; nothing to disable")
 		}
 	}
 	// Set any dangling config values

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -198,6 +198,12 @@ var (
 		Value:    11500000,
 		Category: flags.DevCategory,
 	}
+	// ##CROSS: istanbul posa
+	DeveloperNoPoSAFlag = &cli.BoolFlag{
+		Name:     "dev.noposa",
+		Usage:    "Disable Istanbul PoSA (run the chain in pre-PoSA mode by clearing Istanbul.PoSA)",
+		Category: flags.DevCategory,
+	}
 
 	IdentityFlag = &cli.StringFlag{
 		Name:     "identity",
@@ -2003,6 +2009,24 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 			SetDNSDiscoveryDefaults(cfg, params.CrossGenesisHash)
 		case 1:
 			SetDNSDiscoveryDefaults(cfg, params.MainnetGenesisHash)
+		}
+	}
+	// ##CROSS: istanbul posa
+	// --dev.noposa runs the chain in pre-PoSA mode by clearing the Istanbul PoSA
+	// config. This avoids the PoSA system-contract bootstrap (which cannot run on a
+	// fresh chain whose genesis predates the Breakpoint fork). The config is cloned
+	// so the shared package-level default is not mutated. Consensus-affecting: only
+	// for local dev/test chains, not for joining a live PoSA network.
+	if ctx.Bool(DeveloperNoPoSAFlag.Name) {
+		if cfg.Genesis != nil && cfg.Genesis.Config != nil && cfg.Genesis.Config.Istanbul != nil && cfg.Genesis.Config.Istanbul.PoSA != nil {
+			cfgCopy := *cfg.Genesis.Config
+			istCopy := *cfg.Genesis.Config.Istanbul
+			istCopy.PoSA = nil
+			cfgCopy.Istanbul = &istCopy
+			cfg.Genesis.Config = &cfgCopy
+			log.Warn("Istanbul PoSA disabled via --dev.noposa; running in pre-PoSA mode")
+		} else {
+			log.Warn("--dev.noposa set but Istanbul PoSA is not configured for this chain; nothing to disable")
 		}
 	}
 	// Set any dangling config values

--- a/contracts/upgrade.go
+++ b/contracts/upgrade.go
@@ -294,7 +294,7 @@ func TryUpdateSystemContract(config *params.ChainConfig, header *types.Header, l
 		applySystemContractUpgrade(getUpgrade(forks.Prague, chainID), header, statedb, writeLog)
 		upgraded = true
 	}
-	if config.IsOnBreakpoint(header.Number, lastBlockTime, header.Time) {
+	if config.IsOnBreakpoint(header.Number, lastBlockTime, header.Time) && isPoSAConfigured(config) {
 		applySystemContractUpgrade(getUpgrade(forks.Breakpoint, chainID), header, statedb, writeLog)
 		upgraded = true
 	}
@@ -312,10 +312,17 @@ func InitSystemContract(config *params.ChainConfig, header *types.Header, lastBl
 	}
 
 	chainID := config.ChainID.Uint64()
-	if config.IsOnBreakpoint(header.Number, lastBlockTime, header.Time) {
+	if config.IsOnBreakpoint(header.Number, lastBlockTime, header.Time) && isPoSAConfigured(config) {
 		initData = append(initData, getSystemContractInitialization(getUpgrade(forks.Breakpoint, chainID), config, header)...)
 	}
 	return
+}
+
+// isPoSAConfigured reports whether the Istanbul PoSA config is present. When it is
+// not, the Breakpoint PoSA system-contract upgrade is skipped and the chain runs in
+// pre-PoSA mode. ##CROSS: istanbul posa
+func isPoSAConfigured(config *params.ChainConfig) bool {
+	return config.Istanbul != nil && config.Istanbul.PoSA != nil
 }
 
 func applySystemContractUpgrade(upgrade *Upgrade, header *types.Header, statedb vm.StateDB, writeLog bool) {


### PR DESCRIPTION
## Summary
Adds a `--dev.noposa` flag to run an Istanbul chain with PoSA disabled, makes the PoSA system-contract upgrade optional, and guards the flag so it can never affect official or already-running chains.

## Changes
- **`contracts/upgrade.go`** — gate the Breakpoint PoSA system-contract deployment (`TryUpdateSystemContract`) and initialization (`InitSystemContract`) on `isPoSAConfigured(config)`. When PoSA is not configured, the upgrade is skipped instead of panicking with "PoSA configuration is not set". Both paths share the same gate so contracts are never left half-deployed.
- **`cmd/utils/flags.go`** — new `--dev.noposa` (`DeveloperNoPoSAFlag`). When honored, `SetEthConfig` clones the chain config and clears `Istanbul.PoSA` (the shared package-level config is not mutated).
- **`cmd/geth/main.go`** — register the flag.

## Safety guard
`--dev.noposa` is consensus-affecting, so it is honored **only for a fresh datadir on a non-official network**; in every other case it is ignored and the node follows the genesis config:

| Case | Result |
|---|---|
| Cross mainnet (chainID 612055) | ignored → PoSA kept |
| ZoneZero testnet (chainID 612044) | ignored → PoSA kept |
| Already-initialized chaindata (running chain) | ignored → follows stored genesis config |
| Fresh dev chain (CrossDev3 etc., new datadir) | PoSA disabled (intended) |
| Chain with no PoSA config | ignored (nothing to disable) |

- Official networks are blocked by ChainID — accidental use, whether fresh-syncing or already running, never disables PoSA.
- The "already initialized" check uses `rawdb.PreexistingDatabase` (does not open the DB).
- Every case logs a Warn explaining why the flag was applied or ignored.

## Usage
geth --crossdev3 --dev.noposa --mine ...

## Notes
- **Local dev/test only.** The guard automatically blocks official networks and already-initialized chains.
- On a fresh dev chain initialized with this flag, keep passing it on later runs for consistency.

## Testing
- `go build ./...` passes.
- `--dev.noposa` appears in `geth --help`.
- Verified all Breakpoint upgrade paths route through the two gated functions (no bypass).