### PR TITLE
 chore: rebrand CROSS → ONE (chain, native coin, network flags, docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Go Cross
+# ONE Chain
 
-**Go Cross** is the official execution client for the **ONE** blockchain by to-nexus.
+**This repository** is the official execution client for the **ONE** blockchain by to-nexus.
 It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-new consensus engine — **PoSA (Proof of Staked Authority)** — together with the **Breakpoint** hard fork, while remaining fully compatible with modern Ethereum specifications such as EIP-1559, Cancun, and Prague.
 
 > **Naming update (effective 2026-07-23):** The chain was renamed from **CROSS chain** to **ONE chain**, and its native coin from **CROSS** to **ONE**. All chain and coin references in this document use the new names. The mainnet flag is now **`--one`** (the old **`--cross`** still works as a backward-compatible alias). Technical identifiers that mirror the codebase and repositories — the `go-cross` / `cross-contracts` repositories, the `cross_*` RPC namespace, and system-contract names such as `CrossReserve` — are unchanged.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-
 
 | Network | Flag | Chain ID | Breakpoint (UTC) | Notes |
 |---|---|---|---|---|
-| ONE Mainnet | `--one` (alias `--cross`) | **612055** | 2026-06-01 03:00:00 | Production |
+| ONE Mainnet | `--one` | **612055** | 2026-06-01 03:00:00 | Production |
 | ZoneZero (testnet) | `--zonezero` | 612044 | 2026-05-15 03:00:00 | Official public testnet |
 
 The native coin is **ONE**, and all staking, rewards, and slashing are denominated in the native coin.
@@ -87,7 +87,6 @@ The native coin is **ONE**, and all staking, rewards, and slashing are denominat
 
 ```
 ┌────────────────────────────────────────────────────────────────────┐
-│                          Go Cross (geth)                           │
 │                                                                    │
 │  ┌─────────────┐   ┌──────────────────┐   ┌─────────────────────┐  │
 │  │  P2P / eth  │   │ Istanbul Engine  │   │  EVM (Prague-ready) │  │
@@ -359,10 +358,10 @@ docker build -t to-nexus/go-cross:latest -f Dockerfile .
 
 ### 11.1 Initialize the Data Directory
 
-Built-in networks are selected by name as the argument to `init` (one of `cross`, `zonezero`, `crossdev3`, `crossdev`):
+Built-in networks are selected by name as the argument to `init` (one of `one`, `zonezero`, `onedev3`, `onedev`):
 
 ```bash
-./build/bin/geth --datadir <YOUR_DATADIR> init cross
+./build/bin/geth --datadir <YOUR_DATADIR> init one
 ```
 
 To use a custom genesis, just pass the path to `genesis.json` instead.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Go Cross
 
-**Go Cross** is the official execution client for the **Cross** blockchain by to-nexus.
+**Go Cross** is the official execution client for the **ONE** blockchain by to-nexus.
 It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-new consensus engine — **PoSA (Proof of Staked Authority)** — together with the **Breakpoint** hard fork, while remaining fully compatible with modern Ethereum specifications such as EIP-1559, Cancun, and Prague.
+
+> **Naming update (effective 2026-07-23):** The chain was renamed from **CROSS chain** to **ONE chain**, and its native coin from **CROSS** to **ONE**. All chain and coin references in this document use the new names. The mainnet flag is now **`--one`** (the old **`--cross`** still works as a backward-compatible alias). Technical identifiers that mirror the codebase and repositories — the `go-cross` / `cross-contracts` repositories, the `cross_*` RPC namespace, and system-contract names such as `CrossReserve` — are unchanged.
 
 > This release **completely replaces the previous permissioned QBFT (Quorum BFT) consensus with PoSA**.
 > Anyone who stakes the required amount can now participate as a validator, and ordinary users can earn block rewards through delegation.
@@ -41,12 +43,12 @@ It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-
 
 - **Consensus engine**: PoSA (Istanbul message protocol + BLS aggregate signatures + stake-weighted validator election)
 - **Block time**: 1 second
-- **Validator requirements**: ≥ 1,000,000 CROSS self-delegation **plus on-chain whitelist registration after KYB (Know-Your-Business) verification**
-- **Minimum delegator stake**: 5 CROSS
+- **Validator requirements**: ≥ 1,000,000 ONE self-delegation **plus on-chain whitelist registration after KYB (Know-Your-Business) verification**
+- **Minimum delegator stake**: 5 ONE
 - **Unbonding period**: 14 days
 - **Council size**: up to 21 validators (top-staked)
 - **Council rotation period**: 86,400 s (24 hours)
-- **Block reward**: starts at 9.5129376 CROSS/block, halved every year (10 tiers)
+- **Block reward**: starts at 9.5129376 ONE/block, halved every year (10 tiers)
 - **Validator commission**: 5 % by default (configurable, capped at 50 %)
 - **Base fee (EIP-1559 burn)**: 100 % burned (`0x...dEaD`)
 
@@ -59,7 +61,7 @@ It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-
 | Execution Layer (EL) | **go-ethereum v1.15 base** |
 | Consensus engine | **PoSA** (Istanbul Engine + BLS) |
 | Hard forks | Homestead → Berlin → London → Shanghai → Adventure → Cancun → Prague → **Breakpoint** |
-| Breakpoint activation (mainnet Cross) | `BreakpointTime = 1780282800` (2026-06-01 03:00:00 UTC) |
+| Breakpoint activation (mainnet ONE) | `BreakpointTime = 1780282800` (2026-06-01 03:00:00 UTC) |
 | Breakpoint activation (testnet ZoneZero) | `BreakpointTime = 1778814000` (2026-05-15 03:00:00 UTC) |
 | Go version | **1.23 or higher** |
 | RLP, DB, Trie | 1.15 line |
@@ -74,10 +76,10 @@ It is built on top of the **go-ethereum v1.15** codebase and introduces a brand-
 
 | Network | Flag | Chain ID | Breakpoint (UTC) | Notes |
 |---|---|---|---|---|
-| Cross Mainnet | `--cross` | **612055** | 2026-06-01 03:00:00 | Production |
+| ONE Mainnet | `--one` (alias `--cross`) | **612055** | 2026-06-01 03:00:00 | Production |
 | ZoneZero (testnet) | `--zonezero` | 612044 | 2026-05-15 03:00:00 | Official public testnet |
 
-The native coin is **CROSS**, and all staking, rewards, and slashing are denominated in the native coin.
+The native coin is **ONE**, and all staking, rewards, and slashing are denominated in the native coin.
 
 ---
 
@@ -118,7 +120,7 @@ The native coin is **CROSS**, and all staking, rewards, and slashing are denomin
 
 ### 5.1 Overview
 
-PoSA is a **stake-weighted authority consensus** in the spirit of BNB Chain, redesigned for the Cross environment.
+PoSA is a **stake-weighted authority consensus** in the spirit of BNB Chain, redesigned for the ONE environment.
 Whereas the previous QBFT was a permissioned scheme in which “N pre-whitelisted validators ran BFT consensus”, PoSA works as follows:
 
 1. **Anyone** can apply to become a validator through `StakeHub`.
@@ -139,7 +141,7 @@ Whereas the previous QBFT was a permissioned scheme in which “N pre-whiteliste
 | Council Period | 86,400 s (24 h) | `IstanbulParam` / PoSA Config |
 | Elasticity Multiplier | 3 | same |
 | Base Fee Change Denom. | 8 | same |
-| Max / Min Base Fee | 1 CROSS / 1 Gwei | same |
+| Max / Min Base Fee | 1 ONE / 1 Gwei | same |
 
 ### 5.3 Round Flow
 
@@ -190,7 +192,7 @@ Every function honors `whenNotPaused` and the blacklist check.
 
 | Function | Description |
 |---|---|
-| `stake() payable` | Stake for the caller. **Minimum 5 CROSS** |
+| `stake() payable` | Stake for the caller. **Minimum 5 ONE** |
 | `stakeFor(address account) payable` | Stake on behalf of another address |
 | `unstake(uint256 amount)` | Begin unbonding. Claimable after 14 days; up to 10 outstanding requests per account |
 | `claimUnstake([recipient])` | Claim all matured unbonding requests in one call |
@@ -209,7 +211,7 @@ earned(account)
 
 | Function | Description |
 |---|---|
-| `applyValidator(validatorAddr, signerAddr, signerProof, id) payable` | Apply to become a validator. **Requires on-chain whitelist registration after KYB (Know-Your-Business) verification** + 3-9-char alphanumeric `id` + BLS Proof-of-Possession verification + cumulative stake ≥ **1,000,000 CROSS** |
+| `applyValidator(validatorAddr, signerAddr, signerProof, id) payable` | Apply to become a validator. **Requires on-chain whitelist registration after KYB (Know-Your-Business) verification** + 3-9-char alphanumeric `id` + BLS Proof-of-Possession verification + cumulative stake ≥ **1,000,000 ONE** |
 | `updateValidator(newValidatorAddr)` | Change the consensus node address. The old value cannot be reused; 1-day cooldown |
 | `updateSigner(signerAddr, signerProof)` | Rotate the BLS signer key; 1-day cooldown |
 | `revokeValidator()` | Voluntarily resign as validator. The id, validator address, and BLS key are permanently sealed and cannot be reused |
@@ -263,7 +265,7 @@ earned(account)
 
 | Start block (offset) | Per-block reward |
 |---|---|
-| `startBlock + 0y` | **9.5129376 CROSS** |
+| `startBlock + 0y` | **9.5129376 ONE** |
 | `+1y` | 4.7564688 |
 | `+2y` | 2.3782344 |
 | `+3y` | 1.1891172 |
@@ -311,9 +313,9 @@ A validator's effective yield is the above APR plus their own commission and the
 1. Validators that fail to produce a block (round timeout) are counted via the `slashOffline([...])` system call.
 2. Once the cumulative count reaches **`offlineSlashThreshold` (default 50)**, `StakeHub.penalizeOffline` is invoked.
 3. Penalty:
-   - Slash **10,000 CROSS** from the operator's stake (moved from DelegationPool to ProtocolReserve)
+   - Slash **10,000 ONE** from the operator's stake (moved from DelegationPool to ProtocolReserve)
    - **2-day jail** (`offlineJailDuration`); removed from the council immediately
-4. To exit jail, the validator must call `unjail()` themselves, and at that moment the remaining stake must be ≥ 1,000,000 CROSS.
+4. To exit jail, the validator must call `unjail()` themselves, and at that moment the remaining stake must be ≥ 1,000,000 ONE.
 
 ### 9.2 Mitigate
 
@@ -369,7 +371,7 @@ To use a custom genesis, just pass the path to `genesis.json` instead.
 
 ```bash
 ./build/bin/geth \
-  --cross \
+  --one \
   --datadir <YOUR_DATADIR> \
   --syncmode full \
   --http --http.addr 0.0.0.0 --http.port 22001 \
@@ -403,12 +405,12 @@ If you need to retain the full state trie, add:
 1. **Operator account** — the ECDSA account used to register and manage the validator. **Must have completed KYB (Know-Your-Business) and be registered in the on-chain whitelist.**
 2. **Consensus node (validator) account** — the node's `etherbase`, used to sign BFT messages. Recommended to be separate from the operator.
 3. **BLS signer key** — mandatory for committing blocks after Breakpoint.
-4. Self-delegation or recruited delegations totaling at least **1,000,000 CROSS**.
+4. Self-delegation or recruited delegations totaling at least **1,000,000 ONE**.
 
 ### 12.2 Validator Registration Flow
 
 ```text
-(1) From the operator wallet:  StakeHub.stake { value: 1_000_000 CROSS }
+(1) From the operator wallet:  StakeHub.stake { value: 1_000_000 ONE }
 (2) Generate a BLS Proof of Possession:  geth bls generate-proof
 (3) From the operator wallet:  StakeHub.applyValidator(
         validatorAddr,   // actual consensus node address
@@ -423,7 +425,7 @@ If you need to retain the full state trie, add:
 
 ```bash
 ./build/bin/geth \
-  --cross \
+  --one \
   --datadir <YOUR_DATADIR> \
   --syncmode full \
   --mine \
@@ -449,7 +451,7 @@ If you need to retain the full state trie, add:
 | Situation | Recovery |
 |---|---|
 | Voluntary `suspend(endTime)` | Automatically rejoins the council in the next Council Period after `endTime` |
-| `jail` state | Call `unjail()` once the remaining stake is ≥ 1,000,000 CROSS |
+| `jail` state | Call `unjail()` once the remaining stake is ≥ 1,000,000 ONE |
 | Blacklisted | Keeper removes from the blacklist, then call `unjail()` as above |
 
 ---
@@ -479,7 +481,7 @@ Usable as `./build/bin/geth --config config.toml`.
 ```toml
 [Eth]
 SyncMode = "full"
-NetworkId = 612055           # Cross mainnet
+NetworkId = 612055           # ONE mainnet
 
 [Eth.Miner]
 Etherbase = "0x..."          # validator address (only when running as a validator)
@@ -526,7 +528,7 @@ On top of the standard EL modules (`eth`, `net`, `web3`, `txpool`, `debug`, `adm
 
 ### `cross_*`
 
-- `cross_chainConfig` — Cross-specific metadata such as PoSA activation block and RewardStartBlock
+- `cross_chainConfig` — ONE-specific metadata such as PoSA activation block and RewardStartBlock
 - System-contract indexing / reward-log helpers (see `eth/api*` for the full list)
 
 ### Standard EVM Calls
@@ -551,12 +553,12 @@ Key differences vs. the previous QBFT-based release:
 
 | Item | QBFT (Before) | PoSA (After) |
 |---|---|---|
-| Validator eligibility | Fixed whitelist | **KYB (Know-Your-Business) verification + 1 M CROSS stake** — anyone qualifies |
+| Validator eligibility | Fixed whitelist | **KYB (Know-Your-Business) verification + 1 M ONE stake** — anyone qualifies |
 | Number of validators | Fixed N | **21-member council** + unlimited candidates |
 | Block rewards | None / external distribution | **On-chain distribution (RewardHub)**, automatic 5 % commission |
-| Slashing | None | Offline slashing (threshold 50, 10,000 CROSS, 2-day jail) |
+| Slashing | None | Offline slashing (threshold 50, 10,000 ONE, 2-day jail) |
 | Validator refresh | Governance / off-chain coordination | Council rotates **every 24 hours** based on the latest stake ranking |
-| Delegators (stakers) | None | Anyone with 5 CROSS or more; 14-day unbonding |
+| Delegators (stakers) | None | Anyone with 5 ONE or more; 14-day unbonding |
 | Base-fee handling | (N/A) | Entire EIP-1559 base fee burned (`0x...dEaD`) |
 | EL base version | go-ethereum 1.13 | **go-ethereum 1.15** |
 | Activation | Genesis | **Breakpoint = `block.timestamp ≥ 1780282800`** (mainnet, 2026-06-01 03:00:00 UTC) |

--- a/cmd/geth/chaincmd.go
+++ b/cmd/geth/chaincmd.go
@@ -451,13 +451,13 @@ func importHistory(ctx *cli.Context) error {
 	if utils.IsNetworkPreset(ctx) {
 		switch {
 		// ##CROSS: config
-		case ctx.Bool(utils.CrossFlag.Name):
+		case ctx.Bool(utils.OneFlag.Name):
 			network = "cross"
 		case ctx.Bool(utils.ZoneZeroFlag.Name):
 			network = "zonezero"
-		case ctx.Bool(utils.CrossDev3Flag.Name):
+		case ctx.Bool(utils.OneDev3Flag.Name):
 			network = "crossdev3"
-		case ctx.Bool(utils.CrossDevFlag.Name):
+		case ctx.Bool(utils.OneDevFlag.Name):
 			network = "crossdev"
 		// ##
 		case ctx.Bool(utils.MainnetFlag.Name):

--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -305,16 +305,16 @@ func prepare(ctx *cli.Context) {
 	// If we're running a known preset, log it for convenience.
 	switch {
 	// ##CROSS: config
-	case ctx.IsSet(utils.CrossFlag.Name):
+	case ctx.IsSet(utils.OneFlag.Name):
 		log.Info("Starting Geth on Cross mainnet...")
 
 	case ctx.IsSet(utils.ZoneZeroFlag.Name):
 		log.Info("Starting Geth on ZoneZero testnet...")
 
-	case ctx.IsSet(utils.CrossDev3Flag.Name):
+	case ctx.IsSet(utils.OneDev3Flag.Name):
 		log.Info("Starting Geth on Cross dev3net...")
 
-	case ctx.IsSet(utils.CrossDevFlag.Name):
+	case ctx.IsSet(utils.OneDevFlag.Name):
 		log.Info("Starting Geth on Cross devnet...")
 
 	case ctx.IsSet(utils.MainnetFlag.Name):
@@ -355,8 +355,8 @@ func prepare(ctx *cli.Context) {
 	if !ctx.IsSet(utils.CacheFlag.Name) && !ctx.IsSet(utils.NetworkIdFlag.Name) {
 		// Make sure we're not on any supported preconfigured testnet either
 		if !ctx.IsSet(utils.ZoneZeroFlag.Name) && // ##CROSS: config
-			!ctx.IsSet(utils.CrossDev3Flag.Name) &&
-			!ctx.IsSet(utils.CrossDevFlag.Name) && // ##
+			!ctx.IsSet(utils.OneDev3Flag.Name) &&
+			!ctx.IsSet(utils.OneDevFlag.Name) && // ##
 			!ctx.IsSet(utils.HoleskyFlag.Name) &&
 			!ctx.IsSet(utils.SepoliaFlag.Name) &&
 			!ctx.IsSet(utils.HoodiFlag.Name) &&

--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -140,24 +140,27 @@ var (
 		Category: flags.EthCategory,
 	}
 	// ##CROSS: config
-	CrossFlag = &cli.BoolFlag{
-		Name:     "cross",
-		Usage:    "Cross mainnet",
+	OneFlag = &cli.BoolFlag{
+		Name:     "one",
+		Aliases:  []string{"cross"}, // ##CROSS: backward-compatible alias (mainnet renamed CROSS -> ONE, 2026-07-23)
+		Usage:    "ONE mainnet",
 		Category: flags.EthCategory,
 	}
 	ZoneZeroFlag = &cli.BoolFlag{
 		Name:     "zonezero",
-		Usage:    "Cross testnet",
+		Usage:    "ONE testnet",
 		Category: flags.EthCategory,
 	}
-	CrossDev3Flag = &cli.BoolFlag{
-		Name:     "crossdev3",
-		Usage:    "Cross devnet",
+	OneDev3Flag = &cli.BoolFlag{
+		Name:     "onedev3",
+		Aliases:  []string{"crossdev3"}, // ##CROSS: backward-compatible alias (renamed CROSS -> ONE, 2026-07-23)
+		Usage:    "ONE devnet",
 		Category: flags.EthCategory,
 	}
-	CrossDevFlag = &cli.BoolFlag{
-		Name:     "crossdev",
-		Usage:    "Cross devnet",
+	OneDevFlag = &cli.BoolFlag{
+		Name:     "onedev",
+		Aliases:  []string{"crossdev"}, // ##CROSS: backward-compatible alias (renamed CROSS -> ONE, 2026-07-23)
+		Usage:    "ONE devnet",
 		Category: flags.EthCategory,
 	}
 	// ##
@@ -1047,15 +1050,15 @@ var (
 	TestnetFlags = []cli.Flag{
 		// ##CROSS: config
 		ZoneZeroFlag,
-		CrossDev3Flag,
-		CrossDevFlag,
+		OneDev3Flag,
+		OneDevFlag,
 		// ##
 		SepoliaFlag,
 		HoleskyFlag,
 		HoodiFlag,
 	}
 	// NetworkFlags is the flag group of all built-in supported networks.
-	NetworkFlags = append([]cli.Flag{CrossFlag, MainnetFlag}, TestnetFlags...) // ##CROSS: config
+	NetworkFlags = append([]cli.Flag{OneFlag, MainnetFlag}, TestnetFlags...) // ##CROSS: config
 
 	// DatabaseFlags is the flag group of all database flags.
 	DatabaseFlags = []cli.Flag{
@@ -1141,9 +1144,9 @@ func setBootstrapNodes(ctx *cli.Context, cfg *p2p.Config) {
 		// ##CROSS: config
 		case ctx.Bool(ZoneZeroFlag.Name):
 			urls = params.ZoneZeroBootnodes
-		case ctx.Bool(CrossDev3Flag.Name):
+		case ctx.Bool(OneDev3Flag.Name):
 			urls = params.CrossDev3Bootnodes
-		case ctx.Bool(CrossDevFlag.Name):
+		case ctx.Bool(OneDevFlag.Name):
 			urls = params.CrossDevBootnodes
 		case ctx.Bool(MainnetFlag.Name):
 			urls = params.MainnetBootnodes
@@ -1570,9 +1573,9 @@ func SetDataDir(ctx *cli.Context, cfg *node.Config) {
 	// ##CROSS: config
 	case ctx.Bool(ZoneZeroFlag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "zonezero")
-	case ctx.Bool(CrossDev3Flag.Name) && cfg.DataDir == node.DefaultDataDir():
+	case ctx.Bool(OneDev3Flag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "crossdev3")
-	case ctx.Bool(CrossDevFlag.Name) && cfg.DataDir == node.DefaultDataDir():
+	case ctx.Bool(OneDevFlag.Name) && cfg.DataDir == node.DefaultDataDir():
 		cfg.DataDir = filepath.Join(node.DefaultDataDir(), "crossdev")
 	// ##
 	case ctx.Bool(SepoliaFlag.Name) && cfg.DataDir == node.DefaultDataDir():
@@ -1704,7 +1707,7 @@ func setRequiredBlocks(ctx *cli.Context, cfg *ethconfig.Config) {
 // SetEthConfig applies eth-related command line flags to the config.
 func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Avoid conflicting network flags
-	flags.CheckExclusive(ctx, CrossFlag, ZoneZeroFlag, CrossDev3Flag, CrossDevFlag, MainnetFlag, DeveloperFlag, SepoliaFlag, HoleskyFlag, HoodiFlag) // ##CROSS: config
+	flags.CheckExclusive(ctx, OneFlag, ZoneZeroFlag, OneDev3Flag, OneDevFlag, MainnetFlag, DeveloperFlag, SepoliaFlag, HoleskyFlag, HoodiFlag) // ##CROSS: config
 	flags.CheckExclusive(ctx, DeveloperFlag, ExternalSignerFlag)                                                                                     // Can't use both ephemeral unlocked and external signer
 
 	// Set configurations from CLI flags
@@ -1875,7 +1878,7 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 	// Override any default configs for hard coded networks.
 	switch {
 	// ##CROSS: config
-	case ctx.Bool(CrossFlag.Name):
+	case ctx.Bool(OneFlag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612055
 		}
@@ -1887,13 +1890,13 @@ func SetEthConfig(ctx *cli.Context, stack *node.Node, cfg *ethconfig.Config) {
 		}
 		cfg.Genesis = core.DefaultZoneZeroGenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.ZoneZeroGenesisHash)
-	case ctx.Bool(CrossDev3Flag.Name):
+	case ctx.Bool(OneDev3Flag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612088
 		}
 		cfg.Genesis = core.DefaultCrossDev3GenesisBlock()
 		SetDNSDiscoveryDefaults(cfg, params.CrossDev3GenesisHash)
-	case ctx.Bool(CrossDevFlag.Name):
+	case ctx.Bool(OneDevFlag.Name):
 		if !ctx.IsSet(NetworkIdFlag.Name) {
 			cfg.NetworkId = 612066
 		}
@@ -2409,13 +2412,13 @@ func MakeGenesis(ctx *cli.Context) *core.Genesis {
 	var genesis *core.Genesis
 	switch {
 	// ##CROSS: config
-	case ctx.Bool(CrossFlag.Name):
+	case ctx.Bool(OneFlag.Name):
 		genesis = core.DefaultCrossGenesisBlock()
 	case ctx.Bool(ZoneZeroFlag.Name):
 		genesis = core.DefaultZoneZeroGenesisBlock()
-	case ctx.Bool(CrossDev3Flag.Name):
+	case ctx.Bool(OneDev3Flag.Name):
 		genesis = core.DefaultCrossDev3GenesisBlock()
-	case ctx.Bool(CrossDevFlag.Name):
+	case ctx.Bool(OneDevFlag.Name):
 		genesis = core.DefaultCrossDevGenesisBlock()
 	// ##
 	case ctx.Bool(MainnetFlag.Name):


### PR DESCRIPTION
## Summary

Rebrand **CROSS → ONE**, effective **2026-07-23**. The chain is renamed from
**CROSS chain** to **ONE chain**, and its native coin from **CROSS** to **ONE**.
This PR updates the mainnet/devnet network flags and all user-facing docs to the
new names, while keeping backward compatibility for existing operators.

## Changes

### Network flags (`cmd/utils/flags.go`)
- `--cross` → **`--one`** (mainnet), `--crossdev3` → **`--onedev3`**, `--crossdev` → **`--onedev`**
- Old flag names are kept as **backward-compatible aliases**, so existing
  scripts and node setups keep working unchanged.
- Flag usage strings updated to "ONE mainnet" / "ONE devnet" / "ONE testnet" (ZoneZero).
- Go symbols renamed to match: `CrossFlag → OneFlag`, `CrossDev3Flag → OneDev3Flag`,
  `CrossDevFlag → OneDevFlag` (`cmd/geth/main.go`, `cmd/geth/chaincmd.go`).

### Documentation (`README.md`)
- Title `# Go Cross` → `# ONE Chain`; intro subject → "This repository".
- All chain-name and native-coin references (`CROSS` amounts, "Cross Mainnet",
  "Cross environment", etc.) updated to **ONE**.
- Added a top-of-file **Naming update** note documenting the rename and the
  `--cross` → `--one` alias.

## Backward compatibility
- `--cross` / `--crossdev3` / `--crossdev` still resolve to the same networks

